### PR TITLE
Implement metadata views

### DIFF
--- a/contracts/Clock.cdc
+++ b/contracts/Clock.cdc
@@ -1,0 +1,74 @@
+
+/*
+A contract to mock time. 
+
+If you want to mock time create an function in your admin that enables the  Clock
+The clock will then start at block 0
+use the tick method to tick the time. 
+
+```
+		//this is used to mock the clock, NB! Should consider removing this before deploying to mainnet?
+		pub fun tickClock(_ time: UFix64) {
+			pre {
+				self.capability != nil: "Cannot use AdminProxy, ste capability first"
+			}
+			Clock.enable()
+			Clock.tick(time)
+		}
+```
+
+You can then call this from a transaction like this:
+
+```
+import YourThing from "../contracts/YouThing.cdc"
+
+transaction(clock: UFix64) {
+	prepare(account: AuthAccount) {
+
+		let adminClient=account.borrow<&YourThing.AdminProxy>(from: YourThing.AdminProxyStoragePath)!
+		adminClient.tickClock(clock)
+
+	}
+}
+```
+
+In order to read the mocked time you use the following code in cadence
+
+```
+Clock.time()
+```
+
+Limitations: 
+ - all contracts must live in the same account to (ab)use this trick
+
+*/
+pub contract Clock{
+	//want to mock time on emulator. 
+	access(contract) var fakeClock:UFix64
+	access(contract) var enabled:Bool
+
+
+	access(account) fun tick(_ duration: UFix64) {
+		self.fakeClock = self.fakeClock + duration
+	}
+
+
+	access(account) fun enable() {
+		self.enabled=true
+	}
+
+	//mocking the time! Should probably remove self.fakeClock in mainnet?
+	pub fun time() : UFix64 {
+		if self.enabled {
+			return self.fakeClock 
+		}
+		return getCurrentBlock().timestamp
+	}
+
+	init() {
+		self.fakeClock=0.0
+		self.enabled=false
+	}
+
+}
+

--- a/contracts/FungibleToken.cdc
+++ b/contracts/FungibleToken.cdc
@@ -1,0 +1,205 @@
+/**
+
+# The Flow Fungible Token standard
+
+## `FungibleToken` contract interface
+
+The interface that all fungible token contracts would have to conform to.
+If a users wants to deploy a new token contract, their contract
+would need to implement the FungibleToken interface.
+
+Their contract would have to follow all the rules and naming
+that the interface specifies.
+
+## `Vault` resource
+
+Each account that owns tokens would need to have an instance
+of the Vault resource stored in their account storage.
+
+The Vault resource has methods that the owner and other users can call.
+
+## `Provider`, `Receiver`, and `Balance` resource interfaces
+
+These interfaces declare pre-conditions and post-conditions that restrict
+the execution of the functions in the Vault.
+
+They are separate because it gives the user the ability to share
+a reference to their Vault that only exposes the fields functions
+in one or more of the interfaces.
+
+It also gives users the ability to make custom resources that implement
+these interfaces to do various things with the tokens.
+For example, a faucet can be implemented by conforming
+to the Provider interface.
+
+By using resources and interfaces, users of FungibleToken contracts
+can send and receive tokens peer-to-peer, without having to interact
+with a central ledger smart contract. To send tokens to another user,
+a user would simply withdraw the tokens from their Vault, then call
+the deposit function on another user's Vault to complete the transfer.
+
+*/
+
+/// FungibleToken
+///
+/// The interface that fungible token contracts implement.
+///
+pub contract interface FungibleToken {
+
+    /// The total number of tokens in existence.
+    /// It is up to the implementer to ensure that the total supply
+    /// stays accurate and up to date
+    ///
+    pub var totalSupply: UFix64
+
+    /// TokensInitialized
+    ///
+    /// The event that is emitted when the contract is created
+    ///
+    pub event TokensInitialized(initialSupply: UFix64)
+
+    /// TokensWithdrawn
+    ///
+    /// The event that is emitted when tokens are withdrawn from a Vault
+    ///
+    pub event TokensWithdrawn(amount: UFix64, from: Address?)
+
+    /// TokensDeposited
+    ///
+    /// The event that is emitted when tokens are deposited into a Vault
+    ///
+    pub event TokensDeposited(amount: UFix64, to: Address?)
+
+    /// Provider
+    ///
+    /// The interface that enforces the requirements for withdrawing
+    /// tokens from the implementing type.
+    ///
+    /// It does not enforce requirements on `balance` here,
+    /// because it leaves open the possibility of creating custom providers
+    /// that do not necessarily need their own balance.
+    ///
+    pub resource interface Provider {
+
+        /// withdraw subtracts tokens from the owner's Vault
+        /// and returns a Vault with the removed tokens.
+        ///
+        /// The function's access level is public, but this is not a problem
+        /// because only the owner storing the resource in their account
+        /// can initially call this function.
+        ///
+        /// The owner may grant other accounts access by creating a private
+        /// capability that allows specific other users to access
+        /// the provider resource through a reference.
+        ///
+        /// The owner may also grant all accounts access by creating a public
+        /// capability that allows all users to access the provider
+        /// resource through a reference.
+        ///
+        pub fun withdraw(amount: UFix64): @Vault {
+            post {
+                // `result` refers to the return value
+                result.balance == amount:
+                    "Withdrawal amount must be the same as the balance of the withdrawn Vault"
+            }
+        }
+    }
+
+    /// Receiver
+    ///
+    /// The interface that enforces the requirements for depositing
+    /// tokens into the implementing type.
+    ///
+    /// We do not include a condition that checks the balance because
+    /// we want to give users the ability to make custom receivers that
+    /// can do custom things with the tokens, like split them up and
+    /// send them to different places.
+    ///
+    pub resource interface Receiver {
+
+        /// deposit takes a Vault and deposits it into the implementing resource type
+        ///
+        pub fun deposit(from: @Vault)
+    }
+
+    /// Balance
+    ///
+    /// The interface that contains the `balance` field of the Vault
+    /// and enforces that when new Vaults are created, the balance
+    /// is initialized correctly.
+    ///
+    pub resource interface Balance {
+
+        /// The total balance of a vault
+        ///
+        pub var balance: UFix64
+
+        init(balance: UFix64) {
+            post {
+                self.balance == balance:
+                    "Balance must be initialized to the initial balance"
+            }
+        }
+    }
+
+    /// Vault
+    ///
+    /// The resource that contains the functions to send and receive tokens.
+    ///
+    pub resource Vault: Provider, Receiver, Balance {
+
+        // The declaration of a concrete type in a contract interface means that
+        // every Fungible Token contract that implements the FungibleToken interface
+        // must define a concrete `Vault` resource that conforms to the `Provider`, `Receiver`,
+        // and `Balance` interfaces, and declares their required fields and functions
+
+        /// The total balance of the vault
+        ///
+        pub var balance: UFix64
+
+        // The conforming type must declare an initializer
+        // that allows prioviding the initial balance of the Vault
+        //
+        init(balance: UFix64)
+
+        /// withdraw subtracts `amount` from the Vault's balance
+        /// and returns a new Vault with the subtracted balance
+        ///
+        pub fun withdraw(amount: UFix64): @Vault {
+            pre {
+                self.balance >= amount:
+                    "Amount withdrawn must be less than or equal than the balance of the Vault"
+            }
+            post {
+                // use the special function `before` to get the value of the `balance` field
+                // at the beginning of the function execution
+                //
+                self.balance == before(self.balance) - amount:
+                    "New Vault balance must be the difference of the previous balance and the withdrawn Vault"
+            }
+        }
+
+        /// deposit takes a Vault and adds its balance to the balance of this Vault
+        ///
+        pub fun deposit(from: @Vault) {
+            // Assert that the concrete type of the deposited vault is the same
+            // as the vault that is accepting the deposit
+            pre {
+                from.isInstance(self.getType()): 
+                    "Cannot deposit an incompatible token type"
+            }
+            post {
+                self.balance == before(self.balance) + before(from.balance):
+                    "New Vault balance must be the sum of the previous balance and the deposited Vault"
+            }
+        }
+    }
+
+    /// createEmptyVault allows any user to create a new Vault that has a zero balance
+    ///
+    pub fun createEmptyVault(): @Vault {
+        post {
+            result.balance == 0.0: "The newly created Vault must have zero balance"
+        }
+    }
+}

--- a/contracts/MetadataViews.cdc
+++ b/contracts/MetadataViews.cdc
@@ -1,0 +1,740 @@
+import FungibleToken from "./FungibleToken.cdc"
+import NonFungibleToken from "./NonFungibleToken.cdc"
+
+/// This contract implements the metadata standard proposed
+/// in FLIP-0636.
+/// 
+/// Ref: https://github.com/onflow/flow/blob/master/flips/20210916-nft-metadata.md
+/// 
+/// Structs and resources can implement one or more
+/// metadata types, called views. Each view type represents
+/// a different kind of metadata, such as a creator biography
+/// or a JPEG image file.
+///
+pub contract MetadataViews {
+
+    /// Provides access to a set of metadata views. A struct or 
+    /// resource (e.g. an NFT) can implement this interface to provide access to 
+    /// the views that it supports.
+    ///
+    pub resource interface Resolver {
+        pub fun getViews(): [Type]
+        pub fun resolveView(_ view: Type): AnyStruct?
+    }
+
+    /// A group of view resolvers indexed by ID.
+    ///
+    pub resource interface ResolverCollection {
+        pub fun borrowViewResolver(id: UInt64): &{Resolver}
+        pub fun getIDs(): [UInt64]
+    }
+
+    /// Basic view that includes the name, description and thumbnail for an 
+    /// object. Most objects should implement this view.
+    /// NFTView is a group of views used to give a complete picture of an NFT
+    ///
+    pub struct NFTView {
+        pub let id: UInt64
+        pub let uuid: UInt64
+        pub let display: Display?
+        pub let externalURL: ExternalURL?
+        pub let collectionData: NFTCollectionData?
+        pub let collectionDisplay: NFTCollectionDisplay?
+        pub let royalties: Royalties?
+        pub let traits: Traits?
+
+        init(
+            id : UInt64,
+            uuid : UInt64,
+            display : Display?,
+            externalURL : ExternalURL?,
+            collectionData : NFTCollectionData?,
+            collectionDisplay : NFTCollectionDisplay?,
+            royalties : Royalties?,
+            traits: Traits?
+        ) {
+            self.id = id
+            self.uuid = uuid
+            self.display = display
+            self.externalURL = externalURL
+            self.collectionData = collectionData
+            self.collectionDisplay = collectionDisplay
+            self.royalties = royalties
+            self.traits = traits
+        }
+    }
+
+    /// Helper to get an NFT view 
+    ///
+    /// @param id: The NFT id
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A NFTView struct
+    ///
+    pub fun getNFTView(id: UInt64, viewResolver: &{Resolver}) : NFTView {
+        let nftView = viewResolver.resolveView(Type<NFTView>())
+        if nftView != nil {
+            return nftView! as! NFTView
+        }
+
+        return NFTView(
+            id : id,
+            uuid: viewResolver.uuid,
+            display: self.getDisplay(viewResolver),
+            externalURL : self.getExternalURL(viewResolver),
+            collectionData : self.getNFTCollectionData(viewResolver),
+            collectionDisplay : self.getNFTCollectionDisplay(viewResolver),
+            royalties : self.getRoyalties(viewResolver),
+            traits : self.getTraits(viewResolver)
+        )
+    }
+
+    /// Display is a basic view that includes the name, description and
+    /// thumbnail for an object. Most objects should implement this view.
+    ///
+    pub struct Display {
+
+        /// The name of the object. 
+        ///
+        /// This field will be displayed in lists and therefore should
+        /// be short an concise.
+        ///
+        pub let name: String
+
+        /// A written description of the object. 
+        ///
+        /// This field will be displayed in a detailed view of the object,
+        /// so can be more verbose (e.g. a paragraph instead of a single line).
+        ///
+        pub let description: String
+
+        /// A small thumbnail representation of the object.
+        ///
+        /// This field should be a web-friendly file (i.e JPEG, PNG)
+        /// that can be displayed in lists, link previews, etc.
+        ///
+        pub let thumbnail: AnyStruct{File}
+
+        init(
+            name: String,
+            description: String,
+            thumbnail: AnyStruct{File}
+        ) {
+            self.name = name
+            self.description = description
+            self.thumbnail = thumbnail
+        }
+    }
+
+    /// Helper to get Display in a typesafe way
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return An optional Display struct
+    ///
+    pub fun getDisplay(_ viewResolver: &{Resolver}) : Display? {
+        if let view = viewResolver.resolveView(Type<Display>()) {
+            if let v = view as? Display {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// Generic interface that represents a file stored on or off chain. Files 
+    /// can be used to references images, videos and other media.
+    ///
+    pub struct interface File {
+        pub fun uri(): String
+    }
+
+    /// View to expose a file that is accessible at an HTTP (or HTTPS) URL. 
+    ///
+    pub struct HTTPFile: File {
+        pub let url: String
+
+        init(url: String) {
+            self.url = url
+        }
+
+        pub fun uri(): String {
+            return self.url
+        }
+    }
+
+    /// View to expose a file stored on IPFS.
+    /// IPFS images are referenced by their content identifier (CID)
+    /// rather than a direct URI. A client application can use this CID
+    /// to find and load the image via an IPFS gateway.
+    ///
+    pub struct IPFSFile: File {
+
+        /// CID is the content identifier for this IPFS file.
+        ///
+        /// Ref: https://docs.ipfs.io/concepts/content-addressing/
+        ///
+        pub let cid: String
+
+        /// Path is an optional path to the file resource in an IPFS directory.
+        ///
+        /// This field is only needed if the file is inside a directory.
+        ///
+        /// Ref: https://docs.ipfs.io/concepts/file-systems/
+        ///
+        pub let path: String?
+
+        init(cid: String, path: String?) {
+            self.cid = cid
+            self.path = path
+        }
+
+        /// This function returns the IPFS native URL for this file.
+        /// Ref: https://docs.ipfs.io/how-to/address-ipfs-on-web/#native-urls
+        ///
+        /// @return The string containing the file uri
+        ///
+        pub fun uri(): String {
+            if let path = self.path {
+                return "ipfs://".concat(self.cid).concat("/").concat(path)
+            }
+
+            return "ipfs://".concat(self.cid)
+        }
+    }
+
+    /// Optional view for collections that issue multiple objects
+    /// with the same or similar metadata, for example an X of 100 set. This 
+    /// information is useful for wallets and marketplaces.
+    /// An NFT might be part of multiple editions, which is why the edition 
+    /// information is returned as an arbitrary sized array
+    ///
+    pub struct Edition {
+
+        /// The name of the edition
+        /// For example, this could be Set, Play, Series,
+        /// or any other way a project could classify its editions
+        pub let name: String?
+
+        /// The edition number of the object.
+        /// For an "24 of 100 (#24/100)" item, the number is 24.
+        pub let number: UInt64
+
+        /// The max edition number of this type of objects.
+        /// This field should only be provided for limited-editioned objects.
+        /// For an "24 of 100 (#24/100)" item, max is 100.
+        /// For an item with unlimited edition, max should be set to nil.
+        /// 
+        pub let max: UInt64?
+
+        init(name: String?, number: UInt64, max: UInt64?) {
+            if max != nil {
+                assert(number <= max!, message: "The number cannot be greater than the max number!")
+            }
+            self.name = name
+            self.number = number
+            self.max = max
+        }
+    }
+
+    /// Wrapper view for multiple Edition views
+    /// 
+    pub struct Editions {
+
+        /// An arbitrary-sized list for any number of editions
+        /// that the NFT might be a part of
+        pub let infoList: [Edition]
+
+        init(_ infoList: [Edition]) {
+            self.infoList = infoList
+        }
+    }
+
+    /// Helper to get Editions in a typesafe way
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return An optional Editions struct
+    ///
+    pub fun getEditions(_ viewResolver: &{Resolver}) : Editions? {
+        if let view = viewResolver.resolveView(Type<Editions>()) {
+            if let v = view as? Editions {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// View representing a project-defined serial number for a specific NFT
+    /// Projects have different definitions for what a serial number should be
+    /// Some may use the NFTs regular ID and some may use a different 
+    /// classification system. The serial number is expected to be unique among 
+    /// other NFTs within that project
+    ///
+    pub struct Serial {
+        pub let number: UInt64
+
+        init(_ number: UInt64) {
+            self.number = number
+        }
+    }
+
+    /// Helper to get Serial in a typesafe way
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return An optional Serial struct
+    ///
+    pub fun getSerial(_ viewResolver: &{Resolver}) : Serial? {
+        if let view = viewResolver.resolveView(Type<Serial>()) {
+            if let v = view as? Serial {
+                return v
+            }
+        }
+        return nil
+    }
+    
+    /// View that defines the composable royalty standard that gives marketplaces a 
+    /// unified interface to support NFT royalties.
+    ///
+    pub struct Royalty {
+
+        /// Generic FungibleToken Receiver for the beneficiary of the royalty
+        /// Can get the concrete type of the receiver with receiver.getType()
+        /// Recommendation - Users should create a new link for a FlowToken 
+        /// receiver for this using `getRoyaltyReceiverPublicPath()`, and not 
+        /// use the default FlowToken receiver. This will allow users to update 
+        /// the capability in the future to use a more generic capability
+        pub let receiver: Capability<&AnyResource{FungibleToken.Receiver}>
+
+        /// Multiplier used to calculate the amount of sale value transferred to 
+        /// royalty receiver. Note - It should be between 0.0 and 1.0 
+        /// Ex - If the sale value is x and multiplier is 0.56 then the royalty 
+        /// value would be 0.56 * x.
+        /// Generally percentage get represented in terms of basis points
+        /// in solidity based smart contracts while cadence offers `UFix64` 
+        /// that already supports the basis points use case because its 
+        /// operations are entirely deterministic integer operations and support 
+        /// up to 8 points of precision.
+        pub let cut: UFix64
+
+        /// Optional description: This can be the cause of paying the royalty,
+        /// the relationship between the `wallet` and the NFT, or anything else
+        /// that the owner might want to specify.
+        pub let description: String
+
+        init(receiver: Capability<&AnyResource{FungibleToken.Receiver}>, cut: UFix64, description: String) {
+            pre {
+                cut >= 0.0 && cut <= 1.0 : "Cut value should be in valid range i.e [0,1]"
+            }
+            self.receiver = receiver
+            self.cut = cut
+            self.description = description
+        }
+    }
+
+    /// Wrapper view for multiple Royalty views.
+    /// Marketplaces can query this `Royalties` struct from NFTs 
+    /// and are expected to pay royalties based on these specifications.
+    ///
+    pub struct Royalties {
+
+        /// Array that tracks the individual royalties
+        access(self) let cutInfos: [Royalty]
+
+        pub init(_ cutInfos: [Royalty]) {
+            // Validate that sum of all cut multipliers should not be greater than 1.0
+            var totalCut = 0.0
+            for royalty in cutInfos {
+                totalCut = totalCut + royalty.cut
+            }
+            assert(totalCut <= 1.0, message: "Sum of cutInfos multipliers should not be greater than 1.0")
+            // Assign the cutInfos
+            self.cutInfos = cutInfos
+        }
+
+        /// Return the cutInfos list
+        ///
+        /// @return An array containing all the royalties structs
+        ///
+        pub fun getRoyalties(): [Royalty] {
+            return self.cutInfos
+        }
+    }
+
+    /// Helper to get Royalties in a typesafe way
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional Royalties struct
+    ///
+    pub fun getRoyalties(_ viewResolver: &{Resolver}) : Royalties? {
+        if let view = viewResolver.resolveView(Type<Royalties>()) {
+            if let v = view as? Royalties {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// Get the path that should be used for receiving royalties
+    /// This is a path that will eventually be used for a generic switchboard receiver,
+    /// hence the name but will only be used for royalties for now.
+    ///
+    /// @return The PublicPath for the generic FT receiver
+    ///
+    pub fun getRoyaltyReceiverPublicPath(): PublicPath {
+        return /public/GenericFTReceiver
+    }
+
+    /// View to represent, a file with an correspoiding mediaType.
+    ///
+    pub struct Media {
+
+        /// File for the media
+        ///
+        pub let file: AnyStruct{File}
+
+        /// media-type comes on the form of type/subtype as described here 
+        /// https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
+        ///
+        pub let mediaType: String
+
+        init(file: AnyStruct{File}, mediaType: String) {
+          self.file=file
+          self.mediaType=mediaType
+        }
+    }
+
+    /// Wrapper view for multiple media views
+    ///
+    pub struct Medias {
+
+        /// An arbitrary-sized list for any number of Media items
+        pub let items: [Media]
+
+        init(_ items: [Media]) {
+            self.items = items
+        }
+    }
+
+    /// Helper to get Medias in a typesafe way
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional Medias struct
+    ///
+    pub fun getMedias(_ viewResolver: &{Resolver}) : Medias? {
+        if let view = viewResolver.resolveView(Type<Medias>()) {
+            if let v = view as? Medias {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// View to represent a license according to https://spdx.org/licenses/
+    /// This view can be used if the content of an NFT is licensed.
+    ///
+    pub struct License {
+        pub let spdxIdentifier: String
+
+        init(_ identifier: String) {
+            self.spdxIdentifier = identifier
+        }
+    }
+
+    /// Helper to get License in a typesafe way
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional License struct
+    ///
+    pub fun getLicense(_ viewResolver: &{Resolver}) : License? {
+        if let view = viewResolver.resolveView(Type<License>()) {
+            if let v = view as? License {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// View to expose a URL to this item on an external site.
+    /// This can be used by applications like .find and Blocto to direct users 
+    /// to the original link for an NFT.
+    ///
+    pub struct ExternalURL {
+        pub let url: String
+
+        init(_ url: String) {
+            self.url=url
+        }
+    }
+
+    /// Helper to get ExternalURL in a typesafe way
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional ExternalURL struct
+    ///
+    pub fun getExternalURL(_ viewResolver: &{Resolver}) : ExternalURL? {
+        if let view = viewResolver.resolveView(Type<ExternalURL>()) {
+            if let v = view as? ExternalURL {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// View to expose the information needed store and retrieve an NFT.
+    /// This can be used by applications to setup a NFT collection with proper 
+    /// storage and public capabilities.
+    ///
+    pub struct NFTCollectionData {
+        /// Path in storage where this NFT is recommended to be stored.
+        pub let storagePath: StoragePath
+
+        /// Public path which must be linked to expose public capabilities of this NFT
+        /// including standard NFT interfaces and metadataviews interfaces
+        pub let publicPath: PublicPath
+
+        /// Private path which should be linked to expose the provider
+        /// capability to withdraw NFTs from the collection holding NFTs
+        pub let providerPath: PrivatePath
+
+        /// Public collection type that is expected to provide sufficient read-only access to standard
+        /// functions (deposit + getIDs + borrowNFT)
+        /// This field is for backwards compatibility with collections that have not used the standard
+        /// NonFungibleToken.CollectionPublic interface when setting up collections. For new
+        /// collections, this may be set to be equal to the type specified in `publicLinkedType`.
+        pub let publicCollection: Type
+
+        /// Type that should be linked at the aforementioned public path. This is normally a
+        /// restricted type with many interfaces. Notably the `NFT.CollectionPublic`,
+        /// `NFT.Receiver`, and `MetadataViews.ResolverCollection` interfaces are required.
+        pub let publicLinkedType: Type
+
+        /// Type that should be linked at the aforementioned private path. This is normally
+        /// a restricted type with at a minimum the `NFT.Provider` interface
+        pub let providerLinkedType: Type
+
+        /// Function that allows creation of an empty NFT collection that is intended to store
+        /// this NFT.
+        pub let createEmptyCollection: ((): @NonFungibleToken.Collection)
+
+        init(
+            storagePath: StoragePath,
+            publicPath: PublicPath,
+            providerPath: PrivatePath,
+            publicCollection: Type,
+            publicLinkedType: Type,
+            providerLinkedType: Type,
+            createEmptyCollectionFunction: ((): @NonFungibleToken.Collection)
+        ) {
+            pre {
+                publicLinkedType.isSubtype(of: Type<&{NonFungibleToken.CollectionPublic, NonFungibleToken.Receiver, MetadataViews.ResolverCollection}>()): "Public type must include NonFungibleToken.CollectionPublic, NonFungibleToken.Receiver, and MetadataViews.ResolverCollection interfaces."
+                providerLinkedType.isSubtype(of: Type<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection}>()): "Provider type must include NonFungibleToken.Provider, NonFungibleToken.CollectionPublic, and MetadataViews.ResolverCollection interface."
+            }
+            self.storagePath=storagePath
+            self.publicPath=publicPath
+            self.providerPath = providerPath
+            self.publicCollection=publicCollection
+            self.publicLinkedType=publicLinkedType
+            self.providerLinkedType = providerLinkedType
+            self.createEmptyCollection=createEmptyCollectionFunction
+        }
+    }
+
+    /// Helper to get NFTCollectionData in a way that will return an typed Optional
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional NFTCollectionData struct
+    ///
+    pub fun getNFTCollectionData(_ viewResolver: &{Resolver}) : NFTCollectionData? {
+        if let view = viewResolver.resolveView(Type<NFTCollectionData>()) {
+            if let v = view as? NFTCollectionData {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// View to expose the information needed to showcase this NFT's
+    /// collection. This can be used by applications to give an overview and 
+    /// graphics of the NFT collection this NFT belongs to.
+    ///
+    pub struct NFTCollectionDisplay {
+        // Name that should be used when displaying this NFT collection.
+        pub let name: String
+
+        // Description that should be used to give an overview of this collection.
+        pub let description: String
+
+        // External link to a URL to view more information about this collection.
+        pub let externalURL: ExternalURL
+
+        // Square-sized image to represent this collection.
+        pub let squareImage: Media
+
+        // Banner-sized image for this collection, recommended to have a size near 1200x630.
+        pub let bannerImage: Media
+
+        // Social links to reach this collection's social homepages.
+        // Possible keys may be "instagram", "twitter", "discord", etc.
+        pub let socials: {String: ExternalURL}
+
+        init(
+            name: String,
+            description: String,
+            externalURL: ExternalURL,
+            squareImage: Media,
+            bannerImage: Media,
+            socials: {String: ExternalURL}
+        ) {
+            self.name = name
+            self.description = description
+            self.externalURL = externalURL
+            self.squareImage = squareImage
+            self.bannerImage = bannerImage
+            self.socials = socials
+        }
+    }
+
+    /// Helper to get NFTCollectionDisplay in a way that will return a typed 
+    /// Optional
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional NFTCollection struct
+    ///
+    pub fun getNFTCollectionDisplay(_ viewResolver: &{Resolver}) : NFTCollectionDisplay? {
+        if let view = viewResolver.resolveView(Type<NFTCollectionDisplay>()) {
+            if let v = view as? NFTCollectionDisplay {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// View to expose rarity information for a single rarity
+    /// Note that a rarity needs to have either score or description but it can 
+    /// have both
+    ///
+    pub struct Rarity {
+        /// The score of the rarity as a number
+        pub let score: UFix64?
+
+        /// The maximum value of score
+        pub let max: UFix64?
+
+        /// The description of the rarity as a string.
+        ///
+        /// This could be Legendary, Epic, Rare, Uncommon, Common or any other string value
+        pub let description: String?
+
+        init(score: UFix64?, max: UFix64?, description: String?) {
+            if score == nil && description == nil {
+                panic("A Rarity needs to set score, description or both")
+            }
+
+            self.score = score
+            self.max = max
+            self.description = description
+        }
+    }
+
+    /// Helper to get Rarity view in a typesafe way
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional Rarity struct
+    ///
+    pub fun getRarity(_ viewResolver: &{Resolver}) : Rarity? {
+        if let view = viewResolver.resolveView(Type<Rarity>()) {
+            if let v = view as? Rarity {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// View to represent a single field of metadata on an NFT.
+    /// This is used to get traits of individual key/value pairs along with some
+    /// contextualized data about the trait
+    ///
+    pub struct Trait {
+        // The name of the trait. Like Background, Eyes, Hair, etc.
+        pub let name: String
+
+        // The underlying value of the trait, the rest of the fields of a trait provide context to the value.
+        pub let value: AnyStruct
+
+        // displayType is used to show some context about what this name and value represent
+        // for instance, you could set value to a unix timestamp, and specify displayType as "Date" to tell
+        // platforms to consume this trait as a date and not a number
+        pub let displayType: String?
+
+        // Rarity can also be used directly on an attribute.
+        //
+        // This is optional because not all attributes need to contribute to the NFT's rarity.
+        pub let rarity: Rarity?
+
+        init(name: String, value: AnyStruct, displayType: String?, rarity: Rarity?) {
+            self.name = name
+            self.value = value
+            self.displayType = displayType
+            self.rarity = rarity
+        }
+    }
+
+    /// Wrapper view to return all the traits on an NFT.
+    /// This is used to return traits as individual key/value pairs along with
+    /// some contextualized data about each trait.
+    pub struct Traits {
+        pub let traits: [Trait]
+
+        init(_ traits: [Trait]) {
+            self.traits = traits
+        }
+            
+        /// Adds a single Trait to the Traits view
+        /// 
+        /// @param Trait: The trait struct to be added
+        ///
+        pub fun addTrait(_ t: Trait) {
+            self.traits.append(t)
+        }
+    }
+
+    /// Helper to get Traits view in a typesafe way
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional Traits struct
+    ///
+    pub fun getTraits(_ viewResolver: &{Resolver}) : Traits? {
+        if let view = viewResolver.resolveView(Type<Traits>()) {
+            if let v = view as? Traits {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// Helper function to easily convert a dictionary to traits. For NFT 
+    /// collections that do not need either of the optional values of a Trait, 
+    /// this method should suffice to give them an array of valid traits.
+    ///
+    /// @param dict: The dictionary to be converted to Traits
+    /// @param excludedNames: An optional String array specifying the `dict`
+    ///         keys that are not wanted to become `Traits`
+    /// @return The generated Traits view
+    ///
+    pub fun dictToTraits(dict: {String: AnyStruct}, excludedNames: [String]?): Traits {
+        // Collection owners might not want all the fields in their metadata included.
+        // They might want to handle some specially, or they might just not want them included at all.
+        if excludedNames != nil {
+            for k in excludedNames! {
+                dict.remove(key: k)
+            }
+        }
+
+        let traits: [Trait] = []
+        for k in dict.keys {
+            let trait = Trait(name: k, value: dict[k]!, displayType: nil, rarity: nil)
+            traits.append(trait)
+        }
+
+        return Traits(traits)
+    }
+
+}
+ 

--- a/contracts/Profile.cdc
+++ b/contracts/Profile.cdc
@@ -1,0 +1,666 @@
+/*
+* Inspiration: https://flow-view-source.com/testnet/account/0xba1132bc08f82fe2/contract/Ghost
+*/
+
+import FungibleToken from "./FungibleToken.cdc"
+import ProfileCache from "./ProfileCache.cdc"
+
+pub contract Profile {
+	pub let publicPath: PublicPath
+	pub let publicReceiverPath: PublicPath
+	pub let storagePath: StoragePath
+
+	//and event emitted when somebody follows another user
+	pub event Follow(follower:Address, following: Address, tags: [String])
+
+	//an event emitted when somebody unfollows somebody
+	pub event Unfollow(follower:Address, unfollowing: Address)
+
+	//and event emitted when a user verifies something
+	pub event Verification(account:Address, message:String)
+
+	pub event Created(account:Address, userName:String, findName:String, createdAt:String)
+	pub event Updated(account:Address, userName:String, findName:String, thumbnail:String)
+
+	/* 
+	Represents a Fungible token wallet with a name and a supported type.
+	*/
+	pub struct Wallet {
+		pub let name: String
+		pub let receiver: Capability<&{FungibleToken.Receiver}>
+		pub let balance: Capability<&{FungibleToken.Balance}>
+		pub let accept: Type
+		pub let tags: [String]
+
+		init(
+			name: String,
+			receiver: Capability<&{FungibleToken.Receiver}>,
+			balance: Capability<&{FungibleToken.Balance}>,
+			accept: Type,
+			tags: [String]
+		) {
+			self.name=name
+			self.receiver=receiver
+			self.balance=balance
+			self.accept=accept
+			self.tags=tags
+		}
+	}
+
+	/*
+
+	Represent a collection of a Resource that you want to expose
+	Since NFT standard is not so great at just add Type and you have to use instanceOf to check for now
+	*/
+	pub struct ResourceCollection {
+		pub let collection: Capability
+		pub let tags: [String]
+		pub let type: Type
+		pub let name: String
+
+		init(name: String, collection:Capability, type: Type, tags: [String]) {
+			self.name=name
+			self.collection=collection
+			self.tags=tags
+			self.type=type
+		}
+	}
+
+
+	pub struct CollectionProfile{
+		pub let tags: [String]
+		pub let type: String
+		pub let name: String
+
+		init(_ collection: ResourceCollection){
+			self.name=collection.name
+			self.type=collection.type.identifier
+			self.tags=collection.tags
+		}
+	}
+
+	/*
+	A link that you could add to your profile
+	*/
+	pub struct Link {
+		pub let url: String
+		pub let title: String
+		pub let type: String
+
+		init(title: String, type: String, url: String) {
+			self.url=url
+			self.title=title
+			self.type=type
+		}
+	}
+
+	/*
+	Information about a connection between one profile and another.
+	*/
+	pub struct FriendStatus {
+		pub let follower: Address
+		pub let following:Address
+		pub let tags: [String]
+
+		init(follower: Address, following:Address, tags: [String]) {
+			self.follower=follower
+			self.following=following 
+			self.tags= tags
+		}
+	}
+
+	pub struct WalletProfile {
+		pub let name: String
+		pub let balance: UFix64
+		pub let accept:  String
+		pub let tags: [String] 
+
+		init(_ wallet: Wallet) {
+			self.name=wallet.name
+			self.balance=wallet.balance.borrow()?.balance ?? 0.0 
+			self.accept=wallet.accept.identifier
+			self.tags=wallet.tags
+		}
+	}
+
+	//This is the new return struct from the profile
+	pub struct UserReport {
+		pub let findName: String
+		pub let createdAt: String
+		pub let address: Address
+		pub let name: String
+		pub let gender: String
+		pub let description: String
+		pub let tags: [String]
+		pub let avatar: String
+		pub let links: {String:Link}
+		pub let wallets: [WalletProfile]
+		pub let following: [FriendStatus]
+		pub let followers: [FriendStatus]
+		pub let allowStoringFollowers: Bool
+
+		init(
+			findName:String,
+			address: Address,
+			name: String,
+			gender: String,
+			description: String, 
+			tags: [String],
+			avatar: String, 
+			links: {String:Link},
+			wallets: [WalletProfile],
+			following: [FriendStatus],
+			followers: [FriendStatus],
+			allowStoringFollowers:Bool,
+			createdAt: String
+		) {
+			self.findName=findName
+			self.address=address
+			self.name=name
+			self.gender=gender
+			self.description=description
+			self.tags=tags
+			self.avatar=avatar
+			self.links=links
+			self.wallets=wallets
+			self.following=following
+			self.followers=followers
+			self.allowStoringFollowers=allowStoringFollowers
+			self.createdAt=createdAt
+		}
+	}
+
+
+
+	//This format is deperated
+	pub struct UserProfile {
+		pub let findName: String
+		pub let createdAt: String
+		pub let address: Address
+		pub let name: String
+		pub let gender: String
+		pub let description: String
+		pub let tags: [String]
+		pub let avatar: String
+		pub let links: [Link]
+		pub let wallets: [WalletProfile]
+		pub let collections: [CollectionProfile]
+		pub let following: [FriendStatus]
+		pub let followers: [FriendStatus]
+		pub let allowStoringFollowers: Bool
+
+		init(
+			findName:String,
+			address: Address,
+			name: String,
+			gender: String,
+			description: String, 
+			tags: [String],
+			avatar: String, 
+			links: [Link],
+			wallets: [WalletProfile],
+			collections: [CollectionProfile],
+			following: [FriendStatus],
+			followers: [FriendStatus],
+			allowStoringFollowers:Bool,
+			createdAt: String
+		) {
+			self.findName=findName
+			self.address=address
+			self.name=name
+			self.gender=gender
+			self.description=description
+			self.tags=tags
+			self.avatar=avatar
+			self.links=links
+			self.collections=collections
+			self.wallets=wallets
+			self.following=following
+			self.followers=followers
+			self.allowStoringFollowers=allowStoringFollowers
+			self.createdAt=createdAt
+		}
+	}
+
+	pub resource interface Public{
+		pub fun getAddress() : Address
+		pub fun getName(): String
+		pub fun getFindName(): String
+		pub fun getCreatedAt(): String
+		pub fun getGender(): String
+		pub fun getDescription(): String
+		pub fun getTags(): [String]
+		pub fun getAvatar(): String
+		pub fun getCollections(): [ResourceCollection] 
+		pub fun follows(_ address: Address) : Bool
+		pub fun getFollowers(): [FriendStatus]
+		pub fun getFollowing(): [FriendStatus]
+		pub fun getWallets() : [Wallet]
+		pub fun hasWallet(_ name: String) : Bool 
+		pub fun getLinks() : [Link]
+		pub fun deposit(from: @FungibleToken.Vault)
+		pub fun supportedFungigleTokenTypes() : [Type]
+		pub fun asProfile() : UserProfile
+		pub fun asReport() : UserReport
+		pub fun isBanned(_ val: Address): Bool
+		pub fun isPrivateModeEnabled() : Bool
+
+		access(contract) fun internal_addFollower(_ val: FriendStatus)
+		access(contract) fun internal_removeFollower(_ address: Address) 
+		access(account) fun setFindName(_ val: String)
+	}
+
+	pub resource interface Owner {
+		pub fun setName(_ val: String) {
+			pre {
+				val.length <= 64: "Name must be 64 or less characters"
+			}
+		}
+
+		pub fun setGender(_ val:String){
+			pre {
+				val.length <= 64: "Gender must be 64 or less characters"
+			}
+		}
+
+		pub fun setAvatar(_ val: String){
+			pre {
+				val.length <= 1024: "Avatar must be 1024 characters or less"
+			}
+		}
+
+		pub fun setTags(_ val: [String])  {
+			pre {
+				Profile.verifyTags(tags: val, tagLength:64, tagSize:32) : "cannot have more then 32 tags of length 64"
+			}
+		}   
+
+		//validate length of description to be 255 or something?
+		pub fun setDescription(_ val: String) {
+			pre {
+				val.length <= 1024: "Description must be 1024 characters or less"
+			}
+		}
+
+		pub fun follow(_ address: Address, tags:[String]) {
+			pre {
+				Profile.verifyTags(tags: tags, tagLength:64, tagSize:32) : "cannot have more then 32 tags of length 64"
+			}
+		}
+		pub fun unfollow(_ address: Address)
+
+		pub fun removeCollection(_ val: String)
+		pub fun addCollection(_ val: ResourceCollection)
+
+		pub fun addWallet(_ val : Wallet) 
+		pub fun removeWallet(_ val: String)
+		pub fun setWallets(_ val: [Wallet])
+		pub fun hasWallet(_ name: String) : Bool 
+		pub fun addLink(_ val: Link)
+		pub fun addLinkWithName(name:String, link:Link)
+
+		pub fun removeLink(_ val: String)
+
+		//Verify that this user has signed something.
+		pub fun verify(_ val:String) 
+
+		//A user must be able to remove a follower since this data in your account is added there by another user
+		pub fun removeFollower(_ val: Address)
+
+		//manage bans
+		pub fun addBan(_ val: Address)
+		pub fun removeBan(_ val: Address)
+		pub fun getBans(): [Address]
+
+		//Set if user is allowed to store followers or now
+		pub fun setAllowStoringFollowers(_ val: Bool)
+
+		//set if this user prefers sensitive information about his account to be kept private, no guarantee here but should be honored
+		pub fun setPrivateMode(_ val: Bool)
+	}
+
+
+	pub resource User: Public, Owner, FungibleToken.Receiver {
+		access(self) var name: String
+		access(self) var findName: String
+		access(self) var createdAt: String
+		access(self) var gender: String
+		access(self) var description: String
+		access(self) var avatar: String
+		access(self) var tags: [String]
+		access(self) var followers: {Address: FriendStatus}
+		access(self) var bans: {Address: Bool}
+		access(self) var following: {Address: FriendStatus}
+		access(self) var collections: {String: ResourceCollection}
+		access(self) var wallets: [Wallet]
+		access(self) var links: {String: Link}
+		access(self) var allowStoringFollowers: Bool
+
+		//this is just a bag of properties if we need more fields here, so that we can do it with contract upgrade
+		access(self) var additionalProperties: {String : String}
+
+		init(name:String, createdAt: String) {
+			let randomNumber = (1 as UInt64) + (unsafeRandom() % 25)
+			self.createdAt=createdAt
+			self.name = name
+			self.findName=""
+			self.gender="" 
+			self.description=""
+			self.tags=[]
+			self.avatar = "https://find.xyz/assets/img/avatars/avatar".concat(randomNumber.toString()).concat(".png")
+			self.followers = {}
+			self.following = {}
+			self.collections={}
+			self.wallets=[]
+			self.links={}
+			self.allowStoringFollowers=true
+			self.bans={}
+			self.additionalProperties={}
+
+		}
+
+		/// We do not have a seperate field for this so we use the additionalProperties 'bag' to store this in
+		pub fun setPrivateMode(_ val: Bool) {
+			var private="true"
+			if !val{
+				private="false"
+			}
+			self.additionalProperties["privateMode"]  = private
+		}
+
+		pub fun emitUpdatedEvent() {
+			emit Updated(account:self.owner!.address, userName:self.name, findName:self.findName, thumbnail:self.createdAt)
+		}
+
+		pub fun emitCreatedEvent() {
+			emit Created(account:self.owner!.address, userName:self.name, findName:self.findName, createdAt:self.createdAt)
+		}
+
+		pub fun isPrivateModeEnabled() : Bool {
+			let boolString= self.additionalProperties["privateMode"]
+			if boolString== nil || boolString=="false" {
+				return false
+			}
+			return true
+		}
+
+		pub fun addBan(_ val: Address) { self.bans[val]= true}
+		pub fun removeBan(_ val:Address) { self.bans.remove(key: val) }
+		pub fun getBans() : [Address] { return self.bans.keys }
+		pub fun isBanned(_ val:Address) : Bool { return self.bans.containsKey(val)}
+
+		pub fun setAllowStoringFollowers(_ val: Bool) {
+			self.allowStoringFollowers=val
+		}
+
+		pub fun verify(_ val:String) {
+			emit Verification(account: self.owner!.address, message:val)
+		}
+
+
+		pub fun asReport() : UserReport {
+			let wallets: [WalletProfile]=[]
+			for w in self.wallets {
+				wallets.append(WalletProfile(w))
+			}
+
+			return UserReport(
+				findName: self.getFindName(),
+				address: self.owner!.address,
+				name: self.getName(),
+				gender: self.getGender(),
+				description: self.getDescription(),
+				tags: self.getTags(),
+				avatar: self.getAvatar(),
+				links: self.getLinksMap(),
+				wallets: wallets, 
+				following: self.getFollowing(),
+				followers: self.getFollowers(),
+				allowStoringFollowers: self.allowStoringFollowers,
+				createdAt:self.getCreatedAt()
+			)
+		}
+
+		pub fun getAddress() : Address {
+			return self.owner!.address
+		}
+
+		pub fun asProfile() : UserProfile {
+			let wallets: [WalletProfile]=[]
+			for w in self.wallets {
+				wallets.append(WalletProfile(w))
+			}
+
+			let collections:[CollectionProfile]=[]
+			for c in self.getCollections() {
+				collections.append(CollectionProfile(c))
+			}
+
+			return UserProfile(
+				findName: self.getFindName(),
+				address: self.owner!.address,
+				name: self.getName(),
+				gender: self.getGender(),
+				description: self.getDescription(),
+				tags: self.getTags(),
+				avatar: self.getAvatar(),
+				links: self.getLinks(),
+				wallets: wallets, 
+				collections: collections,
+				following: self.getFollowing(),
+				followers: self.getFollowers(),
+				allowStoringFollowers: self.allowStoringFollowers,
+				createdAt:self.getCreatedAt()
+			)
+		}
+
+		pub fun getLinksMap() : {String: Link} {
+			return self.links
+		}
+
+		pub fun getLinks() : [Link] {
+			return self.links.values
+		}
+
+		pub fun addLinkWithName(name:String, link:Link) {
+			self.links[name]=link
+		}
+
+		pub fun addLink(_ val: Link) {
+			self.links[val.title]=val
+		}
+
+		pub fun removeLink(_ val: String) {
+			self.links.remove(key: val)
+		}
+
+		pub fun supportedFungigleTokenTypes() : [Type] { 
+			let types: [Type] =[]
+			for w in self.wallets {
+				if !types.contains(w.accept) {
+					types.append(w.accept)
+				}
+			}
+			return types
+		}
+
+		pub fun deposit(from: @FungibleToken.Vault) {
+
+			let walletIndexCache = ProfileCache.getWalletIndex(address: self.owner!.address, walletType: from.getType())
+
+			if walletIndexCache != nil {
+				let ref = self.wallets[walletIndexCache!].receiver.borrow() ?? panic("This vault is not set up. ".concat(from.getType().identifier).concat(self.owner!.address.toString()).concat("  .  ").concat(from.balance.toString()))
+				ref.deposit(from: <- from)
+				return
+			}
+
+			for i , w in self.wallets {
+				if from.isInstance(w.accept) {
+					ProfileCache.setWalletIndexCache(address: self.owner!.address, walletType: from.getType(), index: i)
+					let ref = w.receiver.borrow() ?? panic("This vault is not set up. ".concat(from.getType().identifier).concat(self.owner!.address.toString()).concat("  .  ").concat(from.balance.toString()))
+					ref.deposit(from: <- from)
+					return
+				}
+			} 
+			let identifier=from.getType().identifier
+
+			// Try borrow that in a standard way. Only work for flow, usdc and fusd
+			// Check the vault type
+			var ref : &{FungibleToken.Receiver}? = nil
+			if identifier.slice(from: identifier.length - "FlowToken.Vault".length, upTo: identifier.length ) == "FlowToken.Vault" {
+				ref = self.owner!.getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver).borrow()
+			} else if identifier.slice(from: identifier.length - "FiatToken.Vault".length, upTo: identifier.length ) == "FiatToken.Vault" {
+				ref = self.owner!.getCapability<&{FungibleToken.Receiver}>(/public/USDCVaultReceiver).borrow()
+			} else if identifier.slice(from: identifier.length - "FUSD.Vault".length, upTo: identifier.length ) == "FUSD.Vault" {
+				ref = self.owner!.getCapability<&{FungibleToken.Receiver}>(/public/fusdReceiver).borrow()
+			} 
+
+			if ref != nil {
+				ref!.deposit(from: <- from)
+				return
+			}
+
+			//I need to destroy here for this to compile, but WHY?
+			// oh we dont neet this anymore
+			// destroy from
+			// panic("could not find a supported wallet for:".concat(identifier))
+			panic(identifier.slice(from: identifier.length - "FlowToken.Vault".length, upTo: identifier.length ))
+		}
+
+
+		pub fun hasWallet(_ name: String) : Bool {
+			for wallet in self.wallets {
+				if wallet.name == name || wallet.accept.identifier == name {
+					return wallet.receiver.check()
+				}
+			}
+			return false
+		}
+
+		pub fun getWallets() : [Wallet] { return self.wallets}
+		pub fun addWallet(_ val: Wallet) { self.wallets.append(val) }
+		pub fun removeWallet(_ val: String) {
+			let numWallets=self.wallets.length
+			var i=0
+			while(i < numWallets) {
+				if self.wallets[i].name== val {
+					self.wallets.remove(at: i)
+					ProfileCache.resetWalletIndexCache(address: self.owner!.address)
+					return
+				}
+				i=i+1
+			}
+		}
+
+		pub fun setWallets(_ val: [Wallet]) { 
+			self.wallets=val 
+			ProfileCache.resetWalletIndexCache(address: self.owner!.address)
+			}
+
+		pub fun removeFollower(_ val: Address) {
+			self.followers.remove(key:val)
+		}
+
+		pub fun follows(_ address: Address) : Bool {
+			return self.following.containsKey(address)
+		}
+
+		pub fun getName(): String { return self.name }
+		pub fun getFindName(): String { return self.findName }
+		pub fun getCreatedAt(): String { return self.createdAt }
+		pub fun getGender() : String { return self.gender }
+		pub fun getDescription(): String{ return self.description}
+		pub fun getTags(): [String] { return self.tags}
+		pub fun getAvatar(): String { return self.avatar }
+		pub fun getFollowers(): [FriendStatus] { return self.followers.values }
+		pub fun getFollowing(): [FriendStatus] { return self.following.values }
+
+		pub fun setName(_ val: String) { self.name = val }
+		pub fun setFindName(_ val: String) { 
+			emit Updated(account:self.owner!.address, userName:self.name, findName:val, thumbnail:self.avatar)
+			ProfileCache.resetLeaseCache(address: self.owner!.address, leaseName: self.findName)
+			self.findName = val 
+		}
+		pub fun setGender(_ val: String) { self.gender = val }
+		pub fun setAvatar(_ val: String) { self.avatar = val }
+		pub fun setDescription(_ val: String) { self.description=val}
+		pub fun setTags(_ val: [String]) { self.tags=val}
+
+		pub fun removeCollection(_ val: String) { self.collections.remove(key: val)}
+		pub fun addCollection(_ val: ResourceCollection) { self.collections[val.name]=val}
+		pub fun getCollections(): [ResourceCollection] { return self.collections.values}
+
+
+		pub fun follow(_ address: Address, tags:[String]) {
+			let friendProfile=Profile.find(address)
+			let owner=self.owner!.address
+			let status=FriendStatus(follower:owner, following:address, tags:tags)
+
+			self.following[address] = status
+			friendProfile.internal_addFollower(status)
+			emit Follow(follower:owner, following: address, tags:tags)
+		}
+
+		pub fun unfollow(_ address: Address) {
+			self.following.remove(key: address)
+			Profile.find(address).internal_removeFollower(self.owner!.address)
+			emit Unfollow(follower: self.owner!.address, unfollowing:address)
+		}
+
+		access(contract) fun internal_addFollower(_ val: FriendStatus) {
+			if self.allowStoringFollowers && !self.bans.containsKey(val.follower) {
+				self.followers[val.follower] = val
+			}
+		}
+
+		access(contract) fun internal_removeFollower(_ address: Address) {
+			if self.followers.containsKey(address) {
+				self.followers.remove(key: address)
+			}
+		}
+
+	}
+
+	pub fun findWalletCapability(_ address: Address) : Capability<&{FungibleToken.Receiver}> {
+		return getAccount(address)
+		.getCapability<&{FungibleToken.Receiver}>(Profile.publicReceiverPath)
+	}
+
+	pub fun find(_ address: Address) : &{Profile.Public} {
+		return getAccount(address)
+		.getCapability<&{Profile.Public}>(Profile.publicPath)
+		.borrow()!
+	}
+
+
+	pub fun createUser(name: String, createdAt:String) : @Profile.User {
+
+		if name.length > 64 {
+			panic("Name must be 64 or less characters")
+		}
+		if createdAt.length > 32 {
+			panic("createdAt must be 32 or less characters")
+		}
+
+		return <- create Profile.User(name: name,createdAt: createdAt)
+	}
+
+	pub fun verifyTags(tags : [String], tagLength: Int, tagSize: Int): Bool {
+		if tags.length > tagSize {
+			return false
+		}
+
+		for t in tags {
+			if t.length > tagLength {
+				return false
+			}
+		}
+		return true
+	}
+
+	init() {
+		self.publicPath = /public/findProfile
+		self.publicReceiverPath = /public/findProfileReceiver
+		self.storagePath = /storage/findProfile
+	}
+}

--- a/contracts/ProfileCache.cdc
+++ b/contracts/ProfileCache.cdc
@@ -1,0 +1,99 @@
+import Clock from "./Clock.cdc"
+
+pub contract ProfileCache {
+
+	// If there is no findName, the string is set to "". 
+	access(contract) let addressLeaseName : {Address : LeaseCache}
+	access(contract) let nameAddress : {String : LeaseCache}
+
+	access(contract) let profileWalletIndex : {Address : {Type : Int}}
+
+	// Find Leases
+	pub struct LeaseCache {
+		pub let address : Address?
+		pub let leaseName : String 
+		pub let validUntil : UFix64 
+
+		init(leaseName: String, validUntil: UFix64, address: Address?) {
+			self.leaseName=leaseName 
+			self.validUntil=validUntil
+			self.address=address
+		}
+	}
+
+	access(account) fun setAddressLeaseNameCache(address: Address, leaseName: String?, validUntil: UFix64) {
+		if self.addressLeaseName[address] == nil {
+			if leaseName == nil {
+				self.addressLeaseName[address] = LeaseCache(leaseName: "", validUntil: validUntil, address: address)
+				return
+			}
+			self.addressLeaseName[address] = LeaseCache(leaseName: leaseName!, validUntil: validUntil, address: address)
+			return
+		} 
+		// panic("There is already a cache for this address. Address : ".concat(address.toString()))
+		// We cannot panic here, because imagine someone has expired lease. 
+ 	}
+
+	pub fun getAddressLeaseName(_ address: Address) : String? {
+		if self.addressLeaseName[address] == nil {
+			return nil
+		}
+		if self.addressLeaseName[address]!.validUntil >= Clock.time() {
+			return self.addressLeaseName[address]!.leaseName
+		}
+		return nil
+	}
+
+	access(account) fun setNameAddressCache(address: Address?, leaseName: String, validUntil: UFix64) {
+		if self.nameAddress[leaseName] == nil {
+			self.nameAddress[leaseName] = LeaseCache(leaseName: leaseName, validUntil: validUntil, address: address)
+			return
+		} 
+		panic("There is already a cache for this name. Name : ".concat(leaseName))
+ 	}
+
+	pub fun getNameAddress(_ name: String) : LeaseCache? {
+		if self.nameAddress[name]!.validUntil >= Clock.time() {
+			return self.nameAddress[name]
+		}
+		return nil
+	}
+
+	access(account) fun resetLeaseCache(address: Address, leaseName: String) {
+		self.addressLeaseName.remove(key: address)
+		self.nameAddress.remove(key: leaseName)
+	}
+
+
+
+	access(account) fun setWalletIndexCache(address: Address, walletType: Type, index: Int) {
+		if self.profileWalletIndex[address] == nil {
+			self.profileWalletIndex[address] = {}
+			self.profileWalletIndex[address]!.insert(key: walletType, index)
+			return
+		} else if self.profileWalletIndex[address]![walletType] == nil{
+			self.profileWalletIndex[address]!.insert(key: walletType, index)
+			return
+		}
+		panic("There is already a cache for this wallet. User : ".concat(address.toString()).concat(". Wallet : ").concat(walletType.identifier))
+ 	}
+
+	pub fun getWalletIndex(address: Address, walletType: Type) : Int? {
+		if self.profileWalletIndex[address] == nil {
+			return nil
+		}
+		return self.profileWalletIndex[address]![walletType]
+	}
+
+	access(account) fun resetWalletIndexCache(address: Address) {
+		self.profileWalletIndex.remove(key: address)
+	}
+
+	init() {
+		self.addressLeaseName = {}
+		self.nameAddress = {}
+
+		self.profileWalletIndex = {}
+	}
+
+}

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -333,7 +333,7 @@ pub contract XGStudio: NonFungibleToken {
 
             //Default behaviour
             if (templateData["thumbnail"] != nil) {
-                let cid = templateData["thumbnail"] as! String
+                let cid = templateData["thumbnail"] as! String? ?? ""
                 return MetadataViews.IPFSFile(cid, "")
             }
 

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -271,18 +271,18 @@ pub contract XGStudio: NonFungibleToken {
                     ])
                 case Type<MetadataViews.NFTCollectionDisplay>():
                     return MetadataViews.NFTCollectionDisplay(
-                        name: brand.brandName == "xGrunning" ? "xGMove" : brand.brandName,
+                        name: brand.data["name"] ?? "",
                         description: brand.data["description"] ?? "",
-                        externalURL: MetadataViews.ExternalURL(brand.data["websiteUrl"] ?? "https://xgrunning.io"), // @TODO: Update fallback
+                        externalURL: MetadataViews.ExternalURL(brand.data["websiteUrl"] ?? "https://xgrunning.io"),
                         squareImage: MetadataViews.Media(
                             file: MetadataViews.HTTPFile(
-                                url: brand.data["squareImage"] ?? ""
+                                url: brand.data["squareUrl"] ?? ""
                             ),
                             mediaType: "image/png"
                         ),
                         bannerImage: MetadataViews.Media(
                             file: MetadataViews.HTTPFile(
-                                url: brand.data["bannerImage"] ?? ""
+                                url: brand.data["bannerUrl"] ?? ""
                             ),
                             mediaType: "image/png"
                         ),

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -257,9 +257,7 @@ pub contract XGStudio: NonFungibleToken {
                     return MetadataViews.Display(
                         name: (templateData["title"] as! String?) ?? "",
                         description: (templateData["description"] as! String?) ?? "",
-                        thumbnail: MetadataViews.HTTPFile(
-                            url: (templateData["thumbnail"] as! String?) ?? "" // @TODO: Replace with mapping for legacy templates
-                        )
+                        thumbnail: self.getThumbnailFile()
                     )
                 // @TODO: Implement dynamic editions functionality
                 case Type<MetadataViews.Editions>():
@@ -323,7 +321,69 @@ pub contract XGStudio: NonFungibleToken {
 
             return nil
         }
-        
+
+        pub fun getThumbnailFile(): {MetadataViews.File} {
+            let token = XGStudio.getNFTDataById(nftId: self.id)
+            let template =  XGStudio.getTemplateById(templateId: token.templateID)
+            let templateData = template.getImmutableData()
+
+            if (templateData["ipfs"] != nil) {
+                let ipfs = templateData["ipfs"] as! {String: String}
+
+                return MetadataViews.IPFSFile(
+                    ipfs["cid"] ?? "",
+                    ipfs["path"]
+                )
+            }
+
+            if (templateData["raceName"] as! String? == "Hackney Half Marathon 2022") {
+                switch(templateData["nftType"] as! String?) {
+                    case "Finish LE": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/FINISH_LE.png")
+                    case "Finish": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/FINISH.png")
+                    case "1stM": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/1ST.png")
+                    case "1stF": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/1ST.png")
+                    case "2ndM": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/2ND.png")
+                    case "2ndF": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/2ND.png")
+                    case "3rdM": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/3RD.png")
+                    case "3rdF": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/3RD.png")
+                }
+            }
+
+            if (templateData["raceName"] as! String? == "ASICS London 10K 2022") {
+                switch(templateData["nftType"] as! String?) {
+                    case "Finish LE": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "/FINISH_LE.png")
+                    case "Finish": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "/FINISH.png")
+                }
+
+                switch(templateData["title"] as! String?) {
+                    case "1st - ASICS LONDON 10K": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "/1ST.png")
+                    case "2nd - ASICS LONDON 10K": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "/2ND.png")
+                    case "3rd - ASICS LONDON 10K": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "/3RD.png")
+                }
+            }
+
+            if (templateData["raceName"] as! String? == "London Triathlon 2022") {
+                return MetadataViews.IPFSFile("QmSr56aRWEDtD9fEHQrQw9gZjZwYuVK68YUDnHyF1vWcqj", "/TRIATHLON.png")
+            }
+
+            if (templateData["raceName"] as! String? == "London Duathlon 2022") {
+                return MetadataViews.IPFSFile("QmSr56aRWEDtD9fEHQrQw9gZjZwYuVK68YUDnHyF1vWcqj", "/DUATHLON.png")
+            }
+
+            if (templateData["activityType"] as! String? == "Football") {
+                switch(templateData["activityType"] as! String?) {
+                    case "Team Clean Sheet": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/TEAM_CLEANSHEET.png")
+                    case "Goal Scored": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/GOAL_SCORED.png")
+                    case "Team Goals": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/TEAM_GOAL.png")
+                    case "Win": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/WIN.png")
+                    case "Appearance": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/APPEARANCE.png")
+                    case "GK Clean Sheet": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/CLEANSHEET.png")
+                }
+            }
+
+            return MetadataViews.HTTPFile(templateData["thumbnail"] as! String? ?? "")
+        }
+
         destroy() {
             emit NFTDestroyed(id: self.id)
         }

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -289,8 +289,8 @@ pub contract XGStudio: NonFungibleToken {
                             mediaType: "image/png"
                         ),
                         socials: {
-                            // @TODO: Implement dynamic socials list
                             "twitter": MetadataViews.ExternalURL(brand.data["twitter"] ?? ""),
+                            "instagram": MetadataViews.ExternalURL(brand.data["instagram"] ?? ""),
                             "discord": MetadataViews.ExternalURL(brand.data["discord"] ?? "")
                         }
                     )

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -258,7 +258,7 @@ pub contract XGStudio: NonFungibleToken {
                 case Type<MetadataViews.Display>():
                     return MetadataViews.Display(
                         name: (templateData["title"] as! String?) ?? "",
-                        description: (templateData["description"] as! String?) ?? "",
+                        description: self.getAssetDescription(),
                         thumbnail: self.getThumbnailFile()
                     )
                 case Type<MetadataViews.Editions>():
@@ -322,6 +322,45 @@ pub contract XGStudio: NonFungibleToken {
             }
 
             return nil
+        }
+        /*         
+        * Get the NFT description template's thumbnail
+         */
+        pub fun getAssetDescription(): String {
+            let token = XGStudio.getNFTDataById(nftId: self.id)
+            let template =  XGStudio.getTemplateById(templateId: token.templateID)
+            let templateData = template.getImmutableData()
+
+            //Default behaviour
+            if (templateData["description"] != nil) {
+                let description = templateData["description"] as! String? ?? ""
+                return description
+            }
+
+
+            if (templateData["activityType"] as! String? == "Football") {
+                let commonText = 
+                    "\n\nGet xG Rewards for your football achievements.\nBuild your collection - your story.\nUnlock xG experiences.\n\nhttps://linktr.ee/xgstudios"
+                switch(templateData["xGRewardType"] as! String?) {
+                    case "Team Clean Sheet": 
+                        return "Team Clean Sheet: The xG Reward for players who appeared in a fixture where their team kept a clean sheet.".concat(commonText) 
+                    case "Goal Scored": 
+                        return "Goal: The xG Reward for the scorer of every goal.".concat(commonText)
+                    case "Team Goals": 
+                        return "Team Goals: The xG Reward for players who appeared in a fixture where their team scored.\nEach reward includes the total goals scored by their team in the game."
+                            .concat(commonText)  
+                    case "Win": 
+                        return "Win: The xG Reward for players who made an appearance a win.".concat(commonText)
+                    case "Appearance": 
+                        return "Appearance: The xG Reward for players with game time in a fixture.".concat(commonText)
+                    case "GK Clean Sheet": 
+                        return "Clean Sheet: The xG Reward for goalkeepers who keep a clean sheet in a match.".concat(commonText)
+                    case "Hat Trick": 
+                        return "Hat Trick: The xG Reward for scorers of three goals in a match.".concat(commonText)
+                }
+            }
+
+            return ""
         }
 
         /*

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -374,6 +374,7 @@ pub contract XGStudio: NonFungibleToken {
                     case "Win": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/WIN.png")
                     case "Appearance": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/APPEARANCE.png")
                     case "GK Clean Sheet": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/CLEANSHEET.png")
+                    case "Hat Trick": return MetadataViews.IPFSFile("QmbB8panH4gg4A3WpzVdoawHtYcXySLKbEphrEoYs9rZC6", "/HAT_TRICK_THUMB.png")
                 }
             }
 

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -342,7 +342,7 @@ pub contract XGStudio: NonFungibleToken {
             if (templateData["activityType"] as! String? == "Football") {
                 let commonText = 
                     "\n\nGet xG Rewards for your football achievements.\nBuild your collection - your story.\nUnlock xG experiences.\n\nhttps://linktr.ee/xgstudios"
-                switch(templateData["xGRewardType"] as! String?) {
+                switch(templateData["xGRewardType"] as! String? ?? "") {
                     case "Team Clean Sheet": 
                         return "Team Clean Sheet: The xG Reward for players who appeared in a fixture where their team kept a clean sheet.".concat(commonText) 
                     case "Goal Scored": 
@@ -379,12 +379,12 @@ pub contract XGStudio: NonFungibleToken {
             }
 
             if (templateData["raceName"] as! String? == "Hackney Half Marathon 2022") {
-                switch(templateData["nftType"] as! String?) {
+                switch(templateData["nftType"] as! String? ?? "") {
                     case "Finish LE": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "FINISH_LE.png")
                     case "Finish": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "FINISH.png")
                 }
                 
-                switch(templateData["title"] as! String?) {
+                switch(templateData["title"] as! String? ?? "") {
                     case "1st Place - HACKNEY HALF 2022": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "1ST.png")
                     case "2nd Place - HACKNEY HALF 2022": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "2ND.png")
                     case "3rd Place - HACKNEY HALF 2022": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "3RD.png")
@@ -392,12 +392,12 @@ pub contract XGStudio: NonFungibleToken {
             }
 
             if (templateData["raceName"] as! String? == "ASICS London 10K 2022") {
-                switch(templateData["nftType"] as! String?) {
+                switch(templateData["nftType"] as! String? ?? "") {
                     case "Finish LE": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "FINISH_LE.png")
                     case "Finish": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "FINISH.png")
                 }
 
-                switch(templateData["title"] as! String?) {
+                switch(templateData["title"] as! String? ?? "") {
                     case "1st - ASICS LONDON 10K": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "1ST.png")
                     case "2nd - ASICS LONDON 10K": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "2ND.png")
                     case "3rd - ASICS LONDON 10K": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "3RD.png")
@@ -417,7 +417,7 @@ pub contract XGStudio: NonFungibleToken {
             }
 
             if (templateData["activityType"] as! String? == "Football") {
-                switch(templateData["xGRewardType"] as! String?) {
+                switch(templateData["xGRewardType"] as! String? ?? "") {
                     case "Team Clean Sheet": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "TEAM_CLEANSHEET.png")
                     case "Goal Scored": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "GOAL_SCORED.png")
                     case "Team Goals": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "TEAM_GOAL.png")

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -522,16 +522,17 @@ pub contract XGStudio: NonFungibleToken {
             let templateData = template.getImmutableData()
 
             let genericReceiver = getAccount(0x2ce293d39a72a72b).getCapability<&{FungibleToken.Receiver}>(Profile.publicReceiverPath)
+
             // Only add receiver if the Profile capability exists
             let royalties: [MetadataViews.Royalty] = genericReceiver.check() ? [
                 MetadataViews.Royalty(
                     receiver: genericReceiver,
                     cut: 0.025,
-                    description: "xGStudios Cut"
+                    description: "Artist"
                 )
             ] : []
 
-            if (templateData["activityType"] as! String? == "Football") {
+            if (template.brandId == 1) {
                 let receiver = getAccount(0xa6fa47e9ad815dcf).getCapability<&{FungibleToken.Receiver}>(Profile.publicReceiverPath)
 
                 // Only add receiver if the Profile capability exists
@@ -540,12 +541,11 @@ pub contract XGStudio: NonFungibleToken {
                         MetadataViews.Royalty(
                             receiver: receiver,
                             cut: 0.05,
-                            description: "xGFootball Cut"
+                            description: "xGFootball treasury"
                         )
                     )
                 }
-                
-            } else {
+            } else if (template.brandId == 2) {
                 // @TODO: Identify xGMove events
                 let receiver = getAccount(0xc2307c44b0903e33).getCapability<&{FungibleToken.Receiver}>(Profile.publicReceiverPath)
                 
@@ -555,7 +555,7 @@ pub contract XGStudio: NonFungibleToken {
                         MetadataViews.Royalty(
                             receiver: receiver,
                             cut: 0.05,
-                            description: "xGMove Cut"
+                            description: "xGMove treasury"
                         )
                     )
                 }

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -283,7 +283,8 @@ pub contract XGStudio: NonFungibleToken {
                         socials: {
                             "twitter": MetadataViews.ExternalURL(brand.data["twitter"] ?? ""),
                             "instagram": MetadataViews.ExternalURL(brand.data["instagram"] ?? ""),
-                            "discord": MetadataViews.ExternalURL(brand.data["discord"] ?? "")
+                            "discord": MetadataViews.ExternalURL(brand.data["discord"] ?? ""),
+                            "tiktok": MetadataViews.ExternalURL(brand.data["tiktok"] ?? "")
                         }
                     )
                 case Type<MetadataViews.ExternalURL>():

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -273,7 +273,7 @@ pub contract XGStudio: NonFungibleToken {
                     return MetadataViews.NFTCollectionDisplay(
                         name: brand.data["name"] ?? "",
                         description: brand.data["description"] ?? "",
-                        externalURL: MetadataViews.ExternalURL(brand.data["websiteUrl"] ?? "https://xgrunning.io"),
+                        externalURL: MetadataViews.ExternalURL(brand.data["websiteUrl"] ?? "https://xgstudios.io"),
                         squareImage: MetadataViews.Media(
                             file: MetadataViews.HTTPFile(
                                 url: brand.data["squareUrl"] ?? ""
@@ -293,7 +293,7 @@ pub contract XGStudio: NonFungibleToken {
                         }
                     )
                 case Type<MetadataViews.ExternalURL>():
-                    return MetadataViews.ExternalURL((brand.data["websiteUrl"] ?? "https://xgrunning.io").concat("/rewards/").concat(self.id.toString())) // @TODO: Update fallback
+                    return MetadataViews.ExternalURL((brand.data["websiteUrl"] ?? "https://xgstudios.io").concat("/rewards/").concat(self.id.toString()))
                 case Type<MetadataViews.NFTCollectionData>():
                     return MetadataViews.NFTCollectionData(
                         storagePath: XGStudio.CollectionStoragePath,

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -239,7 +239,7 @@ pub contract XGStudio: NonFungibleToken {
                 Type<MetadataViews.NFTCollectionDisplay>(),
                 Type<MetadataViews.ExternalURL>(),
                 Type<MetadataViews.NFTCollectionData>(),
-                //Type<MetadataViews.Royalties>(),
+                Type<MetadataViews.Royalties>(),
                 Type<MetadataViews.Serial>()
             ]
         }
@@ -299,14 +299,14 @@ pub contract XGStudio: NonFungibleToken {
                         })
                     )
                 // @TODO: Implement Royalties
-                // case Type<MetadataViews.Royalties>():
-                //     return MetadataViews.Royalties([
-                //         MetadataViews.Royalty(
-                //             receiver: XGStudio.account.getCapability<&{FungibleToken.Receiver}>(MetadataViews.getRoyaltyReceiverPublicPath()),
-                //             cut: 1337.0,
-                //             description: "REPLACE ME"
-                //         )
-                //     ])
+                case Type<MetadataViews.Royalties>():
+                    return MetadataViews.Royalties([
+                        MetadataViews.Royalty(
+                            receiver: XGStudio.account.getCapability<&{FungibleToken.Receiver}>(MetadataViews.getRoyaltyReceiverPublicPath()),
+                            cut: 0.0,
+                            description: "REPLACE ME"
+                        )
+                    ])
                 case Type<MetadataViews.Serial>():
                     return MetadataViews.Serial(self.id)
             }

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -319,25 +319,22 @@ pub contract XGStudio: NonFungibleToken {
             let template =  XGStudio.getTemplateById(templateId: token.templateID)
             let templateData = template.getImmutableData()
 
-            if (templateData["ipfs"] != nil) {
-                let ipfs = templateData["ipfs"] as! {String: String}
-
-                return MetadataViews.IPFSFile(
-                    ipfs["cid"] ?? "",
-                    ipfs["path"]
-                )
+            //Default behaviour
+            if (templateData["thumbnail"] != nil) {
+                let cid = templateData["thumbnail"] as! String
+                return MetadataViews.IPFSFile(cid, "")
             }
 
             if (templateData["raceName"] as! String? == "Hackney Half Marathon 2022") {
                 switch(templateData["nftType"] as! String?) {
                     case "Finish LE": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/FINISH_LE.png")
                     case "Finish": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/FINISH.png")
-                    case "1stM": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/1ST.png")
-                    case "1stF": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/1ST.png")
-                    case "2ndM": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/2ND.png")
-                    case "2ndF": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/2ND.png")
-                    case "3rdM": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/3RD.png")
-                    case "3rdF": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/3RD.png")
+                }
+                
+                switch(templateData["title"] as! String?) {
+                    case "1st Place - HACKNEY HALF 2022": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/1ST.png")
+                    case "2nd Place - HACKNEY HALF 2022": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/2ND.png")
+                    case "3rd Place - HACKNEY HALF 2022": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/3RD.png")
                 }
             }
 
@@ -367,7 +364,7 @@ pub contract XGStudio: NonFungibleToken {
             }
 
             if (templateData["activityType"] as! String? == "Football") {
-                switch(templateData["activityType"] as! String?) {
+                switch(templateData["xGRewardType"] as! String?) {
                     case "Team Clean Sheet": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/TEAM_CLEANSHEET.png")
                     case "Goal Scored": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/GOAL_SCORED.png")
                     case "Team Goals": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/TEAM_GOAL.png")
@@ -378,7 +375,7 @@ pub contract XGStudio: NonFungibleToken {
                 }
             }
 
-            return MetadataViews.HTTPFile(templateData["thumbnail"] as! String? ?? "")
+            return MetadataViews.HTTPFile("")
         }
 
         pub fun getEditions(): [MetadataViews.Edition] {

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -489,7 +489,7 @@ pub contract XGStudio: NonFungibleToken {
         pub fun borrowXGStudio_NFT(id: UInt64): &XGStudio.NFT? {
             if self.ownedNFTs[id] != nil {
                 let ref = &self.ownedNFTs[id] as auth &NonFungibleToken.NFT?
-                return ref as! &XGStudio.NFT
+                return ref as! &XGStudio.NFT?
             } else {
                 return nil
             }
@@ -739,3 +739,4 @@ pub contract XGStudio: NonFungibleToken {
         emit ContractInitialized()
     }
 }
+ 

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -380,51 +380,51 @@ pub contract XGStudio: NonFungibleToken {
 
             if (templateData["raceName"] as! String? == "Hackney Half Marathon 2022") {
                 switch(templateData["nftType"] as! String?) {
-                    case "Finish LE": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/FINISH_LE.png")
-                    case "Finish": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/FINISH.png")
+                    case "Finish LE": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "FINISH_LE.png")
+                    case "Finish": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "FINISH.png")
                 }
                 
                 switch(templateData["title"] as! String?) {
-                    case "1st Place - HACKNEY HALF 2022": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/1ST.png")
-                    case "2nd Place - HACKNEY HALF 2022": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/2ND.png")
-                    case "3rd Place - HACKNEY HALF 2022": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "/3RD.png")
+                    case "1st Place - HACKNEY HALF 2022": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "1ST.png")
+                    case "2nd Place - HACKNEY HALF 2022": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "2ND.png")
+                    case "3rd Place - HACKNEY HALF 2022": return MetadataViews.IPFSFile("QmUAoUBy4xPRDqH7BKx5ZpVYcFzums9scZu83ccefLrFkr", "3RD.png")
                 }
             }
 
             if (templateData["raceName"] as! String? == "ASICS London 10K 2022") {
                 switch(templateData["nftType"] as! String?) {
-                    case "Finish LE": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "/FINISH_LE.png")
-                    case "Finish": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "/FINISH.png")
+                    case "Finish LE": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "FINISH_LE.png")
+                    case "Finish": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "FINISH.png")
                 }
 
                 switch(templateData["title"] as! String?) {
-                    case "1st - ASICS LONDON 10K": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "/1ST.png")
-                    case "2nd - ASICS LONDON 10K": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "/2ND.png")
-                    case "3rd - ASICS LONDON 10K": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "/3RD.png")
+                    case "1st - ASICS LONDON 10K": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "1ST.png")
+                    case "2nd - ASICS LONDON 10K": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "2ND.png")
+                    case "3rd - ASICS LONDON 10K": return MetadataViews.IPFSFile("Qmdu543z9kvSgX5fS54rpF8sFcX4t5ZbaFBk7YhZFQcn5Y", "3RD.png")
                 }
             }
 
             if (templateData["raceName"] as! String? == "London Triathlon 2022") {
-                return MetadataViews.IPFSFile("QmSr56aRWEDtD9fEHQrQw9gZjZwYuVK68YUDnHyF1vWcqj", "/TRIATHLON.png")
+                return MetadataViews.IPFSFile("QmSr56aRWEDtD9fEHQrQw9gZjZwYuVK68YUDnHyF1vWcqj", "TRIATHLON.png")
             }
 
             if (templateData["raceName"] as! String? == "London Duathlon 2022") {
-                return MetadataViews.IPFSFile("QmSr56aRWEDtD9fEHQrQw9gZjZwYuVK68YUDnHyF1vWcqj", "/DUATHLON.png")
+                return MetadataViews.IPFSFile("QmSr56aRWEDtD9fEHQrQw9gZjZwYuVK68YUDnHyF1vWcqj", "DUATHLON.png")
             }
 
             if (templateData["raceName"] as! String? == "London Duathlon 2022") {
-                return MetadataViews.IPFSFile("QmPYTarYVgKMXQ4wHxGKLURpUKGzWkdUuyY1AkrKXxHDvn", "/xG_GENESIS_FINISH_GNR_THUMB.png")
+                return MetadataViews.IPFSFile("QmPYTarYVgKMXQ4wHxGKLURpUKGzWkdUuyY1AkrKXxHDvn", "xG_GENESIS_FINISH_GNR_THUMB.png")
             }
 
             if (templateData["activityType"] as! String? == "Football") {
                 switch(templateData["xGRewardType"] as! String?) {
-                    case "Team Clean Sheet": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/TEAM_CLEANSHEET.png")
-                    case "Goal Scored": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/GOAL_SCORED.png")
-                    case "Team Goals": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/TEAM_GOAL.png")
-                    case "Win": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/WIN.png")
-                    case "Appearance": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/APPEARANCE.png")
-                    case "GK Clean Sheet": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/CLEANSHEET.png")
-                    case "Hat Trick": return MetadataViews.IPFSFile("QmbB8panH4gg4A3WpzVdoawHtYcXySLKbEphrEoYs9rZC6", "/HAT_TRICK_THUMB.png")
+                    case "Team Clean Sheet": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "TEAM_CLEANSHEET.png")
+                    case "Goal Scored": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "GOAL_SCORED.png")
+                    case "Team Goals": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "TEAM_GOAL.png")
+                    case "Win": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "WIN.png")
+                    case "Appearance": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "APPEARANCE.png")
+                    case "GK Clean Sheet": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "CLEANSHEET.png")
+                    case "Hat Trick": return MetadataViews.IPFSFile("QmbB8panH4gg4A3WpzVdoawHtYcXySLKbEphrEoYs9rZC6", "HAT_TRICK_THUMB.png")
                 }
             }
 

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -300,13 +300,7 @@ pub contract XGStudio: NonFungibleToken {
                     )
                 // @TODO: Implement Royalties
                 case Type<MetadataViews.Royalties>():
-                    return MetadataViews.Royalties([
-                        MetadataViews.Royalty(
-                            receiver: XGStudio.account.getCapability<&{FungibleToken.Receiver}>(MetadataViews.getRoyaltyReceiverPublicPath()),
-                            cut: 0.0,
-                            description: "REPLACE ME"
-                        )
-                    ])
+                    return MetadataViews.Royalties([])
                 case Type<MetadataViews.Serial>():
                     return MetadataViews.Serial(self.id)
             }

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -362,6 +362,10 @@ pub contract XGStudio: NonFungibleToken {
                 return MetadataViews.IPFSFile("QmSr56aRWEDtD9fEHQrQw9gZjZwYuVK68YUDnHyF1vWcqj", "/DUATHLON.png")
             }
 
+            if (templateData["raceName"] as! String? == "London Duathlon 2022") {
+                return MetadataViews.IPFSFile("QmPYTarYVgKMXQ4wHxGKLURpUKGzWkdUuyY1AkrKXxHDvn", "/xG_GENESIS_FINISH_GNR_THUMB.png")
+            }
+
             if (templateData["activityType"] as! String? == "Football") {
                 switch(templateData["activityType"] as! String?) {
                     case "Team Clean Sheet": return MetadataViews.IPFSFile("QmSPFN7uaUaW1H9GsET9HHKudMCLvB5JyFDPxyQ4FoGd5k", "/TEAM_CLEANSHEET.png")

--- a/contracts/XGStudio.cdc
+++ b/contracts/XGStudio.cdc
@@ -533,6 +533,21 @@ pub contract XGStudio: NonFungibleToken {
             ] : []
 
             if (template.brandId == 1) {
+                // xGMove
+                let receiver = getAccount(0xc2307c44b0903e33).getCapability<&{FungibleToken.Receiver}>(Profile.publicReceiverPath)
+
+                // Only add receiver if the Profile capability exists
+                if (receiver.check()) {
+                    royalties.append(
+                        MetadataViews.Royalty(
+                            receiver: receiver,
+                            cut: 0.05,
+                            description: "xGMove treasury"
+                        )
+                    )
+                }
+            } else if (template.brandId == 2) {
+                // xGFootball
                 let receiver = getAccount(0xa6fa47e9ad815dcf).getCapability<&{FungibleToken.Receiver}>(Profile.publicReceiverPath)
 
                 // Only add receiver if the Profile capability exists
@@ -542,20 +557,6 @@ pub contract XGStudio: NonFungibleToken {
                             receiver: receiver,
                             cut: 0.05,
                             description: "xGFootball treasury"
-                        )
-                    )
-                }
-            } else if (template.brandId == 2) {
-                // @TODO: Identify xGMove events
-                let receiver = getAccount(0xc2307c44b0903e33).getCapability<&{FungibleToken.Receiver}>(Profile.publicReceiverPath)
-                
-                // Only add receiver if the Profile capability exists
-                if (receiver.check()) {
-                    royalties.append(
-                        MetadataViews.Royalty(
-                            receiver: receiver,
-                            cut: 0.05,
-                            description: "xGMove treasury"
                         )
                     )
                 }

--- a/flow.json
+++ b/flow.json
@@ -41,11 +41,29 @@
         "testnet": "631e88ae7f1d7c20",
         "mainnet": "1d7e57aa55817448"
       }
+    },
+    "Profile": {
+      "source": "./contracts/Profile.cdc",
+      "aliases": {
+        "mainnet": "097bafa4e0b48eef"
+      }
+    },
+    "ProfileCache": {
+      "source": "./contracts/ProfileCache.cdc",
+      "aliases": {
+        "mainnet": "097bafa4e0b48eef"
+      }
+    },
+    "Clock": {
+      "source": "./contracts/Clock.cdc",
+      "aliases": {
+        "mainnet": "097bafa4e0b48eef"
+      }
     }
   },
   "deployments": {
     "emulator": {
-      "emulator-account": ["XGStudio"]
+      "emulator-account": ["XGStudio", "Profile", "ProfileCache", "Clock"]
     }
   }
 }

--- a/flow.mainnet.json
+++ b/flow.mainnet.json
@@ -8,7 +8,13 @@
   "accounts": {
     "mainnet-deployer": {
       "address": "c357c8d061353f5f",
-      "key": "$MAINNET_PRIVATE_KEY"
+      "key": {
+        "type": "hex",
+        "index": 0,
+        "signatureAlgorithm": "ECDSA_secp256k1",
+        "hashAlgorithm": "SHA3_256",
+        "privateKey":"$MAINNET_PRIVATE_KEY"
+      }
     }
   }
 }

--- a/flow.testnet.json
+++ b/flow.testnet.json
@@ -8,7 +8,13 @@
   "accounts": {
     "testnet-deployer": {
       "address": "d9575c84a88eada0",
-      "key": "$TESTNET_PRIVATE_KEY"
+      "key": {
+        "type": "hex",
+        "index": 0,
+        "signatureAlgorithm": "ECDSA_secp256k1",
+        "hashAlgorithm": "SHA3_256",
+        "privateKey":"$TESTNET_PRIVATE_KEY"
+      }
     }
   }
 }

--- a/scripts/getNFTView.cdc
+++ b/scripts/getNFTView.cdc
@@ -1,0 +1,146 @@
+import XGStudio from "../contracts/XGStudio.cdc"
+import MetadataViews from "../contracts/MetadataViews.cdc"
+
+pub struct NFT {
+    pub let name: String
+    pub let description: String
+    pub let thumbnail: String
+    pub let owner: Address
+    pub let type: String
+    pub let royalties: [MetadataViews.Royalty]
+    pub let externalURL: String
+    pub let serialNumber: UInt64?
+    pub let collectionPublicPath: PublicPath
+    pub let collectionStoragePath: StoragePath
+    pub let collectionProviderPath: PrivatePath
+    pub let collectionPublic: String
+    pub let collectionPublicLinkedType: String
+    pub let collectionProviderLinkedType: String
+    pub let collectionName: String
+    pub let collectionDescription: String
+    pub let collectionExternalURL: String
+    pub let collectionSquareImage: String
+    pub let collectionBannerImage: String
+    pub let collectionSocials: {String: String}
+    pub let edition: MetadataViews.Edition?
+    pub let traits: MetadataViews.Traits?
+		pub let medias: MetadataViews.Medias?
+		pub let license: MetadataViews.License?
+
+    init(
+        name: String,
+        description: String,
+        thumbnail: String,
+        owner: Address,
+        nftType: String,
+        royalties: [MetadataViews.Royalty],
+        externalURL: String,
+        serialNumber: UInt64?,
+        collectionPublicPath: PublicPath,
+        collectionStoragePath: StoragePath,
+        collectionProviderPath: PrivatePath,
+        collectionPublic: String,
+        collectionPublicLinkedType: String,
+        collectionProviderLinkedType: String,
+        collectionName: String,
+        collectionDescription: String,
+        collectionExternalURL: String,
+        collectionSquareImage: String,
+        collectionBannerImage: String,
+        collectionSocials: {String: String},
+        edition: MetadataViews.Edition?,
+        traits: MetadataViews.Traits?,
+				medias: MetadataViews.Medias?,
+				license: MetadataViews.License?
+    ) {
+        self.name = name
+        self.description = description
+        self.thumbnail = thumbnail
+        self.owner = owner
+        self.type = nftType
+        self.royalties = royalties
+        self.externalURL = externalURL
+        self.serialNumber = serialNumber
+        self.collectionPublicPath = collectionPublicPath
+        self.collectionStoragePath = collectionStoragePath
+        self.collectionProviderPath = collectionProviderPath
+        self.collectionPublic = collectionPublic
+        self.collectionPublicLinkedType = collectionPublicLinkedType
+        self.collectionProviderLinkedType = collectionProviderLinkedType
+        self.collectionName = collectionName
+        self.collectionDescription = collectionDescription
+        self.collectionExternalURL = collectionExternalURL
+        self.collectionSquareImage = collectionSquareImage
+        self.collectionBannerImage = collectionBannerImage
+        self.collectionSocials = collectionSocials
+        self.edition = edition
+        self.traits = traits
+				self.medias=medias
+				self.license=license
+    }
+}
+
+pub fun main(address: Address, id: UInt64): NFT {
+    let account = getAccount(address)
+
+    let collection = account
+        .getCapability(XGStudio.CollectionPublicPath)
+        .borrow<&{XGStudio.XGStudioCollectionPublic}>()
+        ?? panic("Could not borrow a reference to the collection")
+
+    let nft = collection.borrowXGStudio_NFT(id: id)!
+
+    // Get the basic display information for this NFT
+    let display = MetadataViews.getDisplay(nft)!
+
+    // Get the royalty information for the given NFT
+    let royaltyView = MetadataViews.getRoyalties(nft)!
+
+    let externalURL = MetadataViews.getExternalURL(nft)!
+
+    let collectionDisplay = MetadataViews.getNFTCollectionDisplay(nft)!
+    let nftCollectionView = MetadataViews.getNFTCollectionData(nft)!
+
+    let nftEditionView = MetadataViews.getEditions(nft)
+    let serialNumberView = MetadataViews.getSerial(nft)
+    
+    let owner: Address = nft.owner!.address
+    let nftType = nft.getType()
+
+    let collectionSocials: {String: String} = {}
+    for key in collectionDisplay.socials.keys {
+        collectionSocials[key] = collectionDisplay.socials[key]!.url
+    }
+
+		let traits = MetadataViews.getTraits(nft)
+
+		let medias=MetadataViews.getMedias(nft)
+		let license=MetadataViews.getLicense(nft)
+
+    return NFT(
+        name: display.name,
+        description: display.description,
+        thumbnail: display.thumbnail.uri(),
+        owner: owner,
+        nftType: nftType.identifier,
+        royalties: royaltyView.getRoyalties(),
+        externalURL: externalURL.url,
+        serialNumber: serialNumberView?.number,
+        collectionPublicPath: nftCollectionView.publicPath,
+        collectionStoragePath: nftCollectionView.storagePath,
+        collectionProviderPath: nftCollectionView.providerPath,
+        collectionPublic: nftCollectionView.publicCollection.identifier,
+        collectionPublicLinkedType: nftCollectionView.publicLinkedType.identifier,
+        collectionProviderLinkedType: nftCollectionView.providerLinkedType.identifier,
+        collectionName: collectionDisplay.name,
+        collectionDescription: collectionDisplay.description,
+        collectionExternalURL: collectionDisplay.externalURL.url,
+        collectionSquareImage: collectionDisplay.squareImage.file.uri(),
+        collectionBannerImage: collectionDisplay.bannerImage.file.uri(),
+        collectionSocials: collectionSocials,
+        edition: nftEditionView != nil ? nftEditionView!.infoList[0] : nil,
+        traits: traits,
+				medias: medias,
+				license: license
+    )
+}

--- a/scripts/getNFTView.cdc
+++ b/scripts/getNFTView.cdc
@@ -22,7 +22,7 @@ pub struct NFT {
     pub let collectionSquareImage: String
     pub let collectionBannerImage: String
     pub let collectionSocials: {String: String}
-    pub let edition: MetadataViews.Edition?
+    pub let editions: [MetadataViews.Edition?]?
     pub let traits: MetadataViews.Traits?
 		pub let medias: MetadataViews.Medias?
 		pub let license: MetadataViews.License?
@@ -48,7 +48,7 @@ pub struct NFT {
         collectionSquareImage: String,
         collectionBannerImage: String,
         collectionSocials: {String: String},
-        edition: MetadataViews.Edition?,
+        editions: [MetadataViews.Edition?]?,
         traits: MetadataViews.Traits?,
 				medias: MetadataViews.Medias?,
 				license: MetadataViews.License?
@@ -73,7 +73,7 @@ pub struct NFT {
         self.collectionSquareImage = collectionSquareImage
         self.collectionBannerImage = collectionBannerImage
         self.collectionSocials = collectionSocials
-        self.edition = edition
+        self.editions = editions
         self.traits = traits
 				self.medias=medias
 				self.license=license
@@ -138,7 +138,7 @@ pub fun main(address: Address, id: UInt64): NFT {
         collectionSquareImage: collectionDisplay.squareImage.file.uri(),
         collectionBannerImage: collectionDisplay.bannerImage.file.uri(),
         collectionSocials: collectionSocials,
-        edition: nftEditionView != nil ? nftEditionView!.infoList[0] : nil,
+        editions: nftEditionView != nil ? nftEditionView!.infoList : nil,
         traits: traits,
 				medias: medias,
 				license: license

--- a/test/js/index-test.test.js
+++ b/test/js/index-test.test.js
@@ -1,16 +1,17 @@
-import path from "path";
 import {
-  init,
-  emulator,
-  getAccountAddress,
   deployContractByName,
-  getContractAddress,
-  getTransactionCode,
-  getScriptCode,
+  emulator,
   executeScript,
+  getAccountAddress,
+  getContractAddress,
+  getScriptCode,
+  getTransactionCode,
+  init,
   sendTransaction,
+  shallPass,
+  shallResolve,
 } from "flow-js-testing";
-import { expect } from "@jest/globals";
+import path from "path";
 
 jest.setTimeout(10000);
 
@@ -36,48 +37,39 @@ describe("Replicate Playground Accounts", () => {
     console.log(
       "Four Playground accounts were created with following addresses"
     );
-    console.log("Alice:", Alice);
-    console.log("Bob:", Bob);
-    console.log("Charlie:", Charlie);
-    console.log("Dave:", Dave);
+    console.table({
+      Alice,
+      Bob,
+      Charlie,
+      Dave,
+    });
   });
 });
 
 describe("Deployment", () => {
-  test("Deploy for NonFungibleToken", async () => {
-    const name = "NonFungibleToken";
+  test("Deploy for library contracts", async () => {
     const to = await getAccountAddress("Alice");
-    let update = true;
 
-    let result;
-    try {
-      result = await deployContractByName({
-        name,
+    await shallPass(
+      deployContractByName({
+        name: "NonFungibleToken",
         to,
-        update,
-      });
+      })
+    );
 
-      await deployContractByName({
+    await shallPass(
+      deployContractByName({
         name: "FungibleToken",
         to,
-        update,
-      });
+      })
+    );
 
-      await deployContractByName({
+    await shallPass(
+      deployContractByName({
         name: "MetadataViews",
         to,
-        update,
-      });
-
-      await deployContractByName({
-        name,
-        to,
-        update,
-      });
-    } catch (e) {
-      console.log(e);
-    }
-    expect(name).toBe("NonFungibleToken");
+      })
+    );
   });
   test("Deploy for XGStudio", async () => {
     const name = "XGStudio";
@@ -93,18 +85,14 @@ describe("Deployment", () => {
       MetadataViews,
     };
 
-    let result;
-    try {
-      result = await deployContractByName({
+    await shallPass(
+      deployContractByName({
         name,
         to,
         addressMap,
         update,
-      });
-    } catch (e) {
-      console.log(e);
-    }
-    expect(name).toBe("XGStudio");
+      })
+    );
   });
 });
 describe("Transactions", () => {
@@ -131,19 +119,13 @@ describe("Transactions", () => {
     });
     const args = ["HondaNorth"];
 
-    let txResult;
-    try {
-      txResult = await sendTransaction({
+    await shallPass(
+      sendTransaction({
         code,
         signers,
         args,
-      });
-    } catch (e) {
-      console.log(e);
-    }
-    console.log("tx Result", txResult[0]);
-
-    // expect(txResult.errorMessage).toBe("");
+      })
+    );
   });
   test("test transaction  create Schema", async () => {
     const name = "createSchema";
@@ -168,19 +150,13 @@ describe("Transactions", () => {
     });
     const args = ["Test Schema"];
 
-    let txResult;
-    try {
-      txResult = await sendTransaction({
+    await shallPass(
+      sendTransaction({
         code,
         signers,
         args,
-      });
-    } catch (e) {
-      console.log(e);
-    }
-    console.log("tx Result", txResult[0]);
-
-    // expect(txResult.errorMessage).toBe("");
+      })
+    );
   });
   test("test transaction  create template", async () => {
     const name = "createTemplateStaticData";
@@ -205,19 +181,14 @@ describe("Transactions", () => {
     });
     // brandId, schemaId, maxSupply,immutableData
     const args = [1, 1, 100];
-    let txResult;
-    try {
-      txResult = await sendTransaction({
+
+    await shallPass(
+      sendTransaction({
         code,
         signers,
         args,
-      });
-    } catch (e) {
-      console.log(e);
-    }
-    console.log("tx Result", txResult[0]);
-
-    // expect(txResult.errorMessage).toBe("");
+      })
+    );
   });
   test("test transaction setup Account", async () => {
     const name = "setupAccount";
@@ -241,18 +212,12 @@ describe("Transactions", () => {
       addressMap,
     });
 
-    let txResult;
-    try {
-      txResult = await sendTransaction({
+    await shallPass(
+      sendTransaction({
         code,
         signers,
-      });
-    } catch (e) {
-      console.log(e);
-    }
-    console.log("tx Result", txResult[0]);
-
-    // expect(txResult.errorMessage).toBe("");
+      })
+    );
   });
 
   test("test transaction  mint NFT", async () => {
@@ -278,19 +243,13 @@ describe("Transactions", () => {
       addressMap,
     });
     const args = [1, Charlie];
-    let txResult;
-    try {
-      txResult = await sendTransaction({
+    await shallPass(
+      sendTransaction({
         code,
         signers,
         args,
-      });
-    } catch (e) {
-      console.log(e);
-    }
-    console.log("tx Result", txResult[0]);
-
-    // expect(txResult.errorMessage).toBe("");
+      })
+    );
   });
 });
 describe("Scripts", () => {
@@ -321,10 +280,11 @@ describe("Scripts", () => {
         return `getAccount(${name})`;
       });
 
-    const result = await executeScript({
-      code,
-    });
-    console.log("result", result);
+    await shallResolve(
+      executeScript({
+        code,
+      })
+    );
   });
   test("get brand data", async () => {
     const name = "getAllBrands";
@@ -353,10 +313,11 @@ describe("Scripts", () => {
         return `getAccount(${name})`;
       });
 
-    const result = await executeScript({
-      code,
-    });
-    console.log("result", result);
+    await shallResolve(
+      executeScript({
+        code,
+      })
+    );
   });
   test("get brand data by Id", async () => {
     const name = "getBrandById";
@@ -386,11 +347,12 @@ describe("Scripts", () => {
         return `getAccount(${name})`;
       });
 
-    const result = await executeScript({
-      code,
-      args,
-    });
-    console.log("result", result);
+    await shallResolve(
+      executeScript({
+        code,
+        args,
+      })
+    );
   });
   test("get schema data", async () => {
     const name = "getallSchema";
@@ -419,10 +381,11 @@ describe("Scripts", () => {
         return `getAccount(${name})`;
       });
 
-    const result = await executeScript({
-      code,
-    });
-    console.log("result", result);
+    await shallResolve(
+      executeScript({
+        code,
+      })
+    );
   });
 
   test("get schema data by Id", async () => {
@@ -452,13 +415,13 @@ describe("Scripts", () => {
         return `getAccount(${name})`;
       });
 
-    console.log(typeof myInt);
     const args = [1];
-    const result = await executeScript({
-      code,
-      args,
-    });
-    console.log("result", result);
+    await shallResolve(
+      executeScript({
+        code,
+        args,
+      })
+    );
   });
 
   test("get template data ", async () => {
@@ -488,10 +451,11 @@ describe("Scripts", () => {
         return `getAccount(${name})`;
       });
 
-    const result = await executeScript({
-      code,
-    });
-    console.log("result", result);
+    await shallResolve(
+      executeScript({
+        code,
+      })
+    );
   });
   test("get template data by Id", async () => {
     const name = "getTemplateById";
@@ -520,11 +484,12 @@ describe("Scripts", () => {
         return `getAccount(${name})`;
       });
     const args = [1];
-    const result = await executeScript({
-      code,
-      args,
-    });
-    console.log("result", result);
+    await shallResolve(
+      executeScript({
+        code,
+        args,
+      })
+    );
   });
 
   test("get all nfts  data", async () => {
@@ -554,11 +519,12 @@ describe("Scripts", () => {
         return `getAccount(${name})`;
       });
     const args = [Charlie];
-    const result = await executeScript({
-      code,
-      args,
-    });
-    console.log("result", result);
+    await shallResolve(
+      executeScript({
+        code,
+        args,
+      })
+    );
   });
 
   test("get nft template data", async () => {
@@ -588,10 +554,12 @@ describe("Scripts", () => {
       });
 
     const args = [Charlie];
-    const result = await executeScript({
-      code,
-      args,
-    });
-    console.log("result", result);
+
+    await shallResolve(
+      executeScript({
+        code,
+        args,
+      })
+    );
   });
 });

--- a/test/js/index-test.test.js
+++ b/test/js/index-test.test.js
@@ -70,6 +70,27 @@ describe("Deployment", () => {
         to,
       })
     );
+
+    await shallPass(
+      deployContractByName({
+        name: "Clock",
+        to,
+      })
+    );
+
+    await shallPass(
+      deployContractByName({
+        name: "ProfileCache",
+        to,
+      })
+    );
+
+    await shallPass(
+      deployContractByName({
+        name: "Profile",
+        to,
+      })
+    );
   });
   test("Deploy for XGStudio", async () => {
     const name = "XGStudio";
@@ -79,10 +100,16 @@ describe("Deployment", () => {
     const NonFungibleToken = await getContractAddress("NonFungibleToken");
     const FungibleToken = await getContractAddress("FungibleToken");
     const MetadataViews = await getContractAddress("MetadataViews");
+    const Clock = await getContractAddress("Clock");
+    const ProfileCache = await getContractAddress("ProfileCache");
+    const Profile = await getContractAddress("Profile");
     const addressMap = {
       NonFungibleToken,
       FungibleToken,
       MetadataViews,
+      Clock,
+      ProfileCache,
+      Profile,
     };
 
     await shallPass(

--- a/test/js/index-test.test.js
+++ b/test/js/index-test.test.js
@@ -563,3 +563,86 @@ describe("Scripts", () => {
     );
   });
 });
+
+describe("MetadataViews", () => {
+  test("NFTView", async () => {
+    // Import participating accounts
+    const Bob = await getAccountAddress("Bob");
+    const Charlie = await getAccountAddress("Charlie");
+
+    // Set transaction signers
+    const signers = [Bob];
+
+    // Generate addressMap from import statements
+    const MetadataViews = await getContractAddress("MetadataViews");
+    const XGStudio = await getContractAddress("XGStudio");
+    const addressMap = {
+      MetadataViews,
+      XGStudio,
+    };
+
+    const [result] = await shallPass(
+      sendTransaction({
+        name: "mintNFT",
+        signers,
+        args: [1, Charlie],
+        addressMap,
+      })
+    );
+
+    const nftID = result.events[0].data.nftId;
+
+    const [nftData] = await shallResolve(
+      executeScript({
+        name: "getNFTView",
+        args: [Charlie, nftID],
+      })
+    );
+
+    expect(nftData).toEqual({
+      name: "Second NFT",
+      description: "Second NFT for the xgStudio",
+      thumbnail: "ipfs://IPFSCID/",
+      owner: "0xf3fcd2c1a78f5eee",
+      type: "A.179b6b1cb6755e31.XGStudio.NFT",
+      royalties: [],
+      externalURL: "https://xgstudios.io/rewards/2",
+      serialNumber: 2,
+      collectionPublicPath: {
+        domain: "public",
+        identifier: "XGStudioCollection",
+      },
+      collectionStoragePath: {
+        domain: "storage",
+        identifier: "XGStudioCollection",
+      },
+      collectionProviderPath: {
+        domain: "private",
+        identifier: "XGStudioCollectionProvider",
+      },
+      collectionPublic:
+        "&A.179b6b1cb6755e31.XGStudio.Collection{A.179b6b1cb6755e31.XGStudio.XGStudioCollectionPublic}",
+      collectionPublicLinkedType:
+        "&A.179b6b1cb6755e31.XGStudio.Collection{A.179b6b1cb6755e31.XGStudio.XGStudioCollectionPublic,A.01cf0e2f2f715450.NonFungibleToken.CollectionPublic,A.01cf0e2f2f715450.NonFungibleToken.Receiver,A.01cf0e2f2f715450.MetadataViews.ResolverCollection}",
+      collectionProviderLinkedType:
+        "&A.179b6b1cb6755e31.XGStudio.Collection{A.179b6b1cb6755e31.XGStudio.XGStudioCollectionPublic,A.01cf0e2f2f715450.NonFungibleToken.CollectionPublic,A.01cf0e2f2f715450.NonFungibleToken.Provider,A.01cf0e2f2f715450.MetadataViews.ResolverCollection}",
+      collectionName: "XGStudio",
+      collectionDescription:
+        "xG® rewards athletes’ real world sports participation with personalised digital collectibles and the xG® utility token.",
+      collectionExternalURL: "https://xgstudios.io",
+      collectionSquareImage:
+        "https://xgstudios.mypinata.cloud/ipfs/QmZP32SFcQ2rN2diEXsnwyFxZ5dmyFhuqAybDRANg2cEsk/XG_MOVE_THUMBNAIL.png",
+      collectionBannerImage:
+        "https://xgstudios.mypinata.cloud/ipfs/QmZP32SFcQ2rN2diEXsnwyFxZ5dmyFhuqAybDRANg2cEsk/XG_MOVE_COLLECTION_BANNER.png",
+      collectionSocials: {
+        discord: "https://discord.com/invite/uaYhFARqXM",
+        instagram: "https://www.instagram.com/xGStudios_/",
+        twitter: "https://twitter.com/xGStudios_",
+      },
+      editions: [{ name: "Second NFT", number: 2, max: 100 }],
+      traits: null,
+      medias: { items: [] },
+      license: null,
+    });
+  });
+});

--- a/test/js/index-test.test.js
+++ b/test/js/index-test.test.js
@@ -56,6 +56,24 @@ describe("Deployment", () => {
         to,
         update,
       });
+
+      await deployContractByName({
+        name: "FungibleToken",
+        to,
+        update,
+      });
+
+      await deployContractByName({
+        name: "MetadataViews",
+        to,
+        update,
+      });
+
+      await deployContractByName({
+        name,
+        to,
+        update,
+      });
     } catch (e) {
       console.log(e);
     }
@@ -67,8 +85,12 @@ describe("Deployment", () => {
     let update = true;
 
     const NonFungibleToken = await getContractAddress("NonFungibleToken");
+    const FungibleToken = await getContractAddress("FungibleToken");
+    const MetadataViews = await getContractAddress("MetadataViews");
     const addressMap = {
       NonFungibleToken,
+      FungibleToken,
+      MetadataViews,
     };
 
     let result;

--- a/test/js/index-test.test.js
+++ b/test/js/index-test.test.js
@@ -665,6 +665,7 @@ describe("MetadataViews", () => {
         discord: "https://discord.com/invite/uaYhFARqXM",
         instagram: "https://www.instagram.com/xGStudios_/",
         twitter: "https://twitter.com/xGStudios_",
+        tiktok: "https://www.tiktok.com/@xgstudios"
       },
       editions: [{ name: "Second NFT", number: 2, max: 100 }],
       traits: null,

--- a/test/js/package.json
+++ b/test/js/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@babel/core": "^7.19.0",
     "@babel/preset-env": "^7.19.0",
+    "@types/jest": "^29.0.3",
     "babel-jest": "^29.0.2",
     "flow-js-testing": "^0.2.3-alpha.6",
     "jest": "^29.0.2",

--- a/transactions/createBrand.cdc
+++ b/transactions/createBrand.cdc
@@ -20,7 +20,8 @@ transaction (brandName:String){
                 "bannerUrl": "https://xgstudios.mypinata.cloud/ipfs/QmZP32SFcQ2rN2diEXsnwyFxZ5dmyFhuqAybDRANg2cEsk/XG_MOVE_COLLECTION_BANNER.png",
                 "discord": "https://discord.com/invite/uaYhFARqXM", 
                 "instagram": "https://www.instagram.com/xGStudios_/", 
-                "twitter": "https://twitter.com/xGStudios_"
+                "twitter": "https://twitter.com/xGStudios_",
+                "tiktok": "https://www.tiktok.com/@xgstudios"
             }
         actorResource.createNewBrand(
             brandName: brandName,

--- a/transactions/createBrand.cdc
+++ b/transactions/createBrand.cdc
@@ -15,7 +15,12 @@ transaction (brandName:String){
             let data  : {String:String} = {
                 "name":"XGStudio",
                 "description":"xG® rewards athletes’ real world sports participation with personalised digital collectibles and the xG® utility token.",
-                "url":"https://xgstudios.io"   
+                "url":"https://xgstudios.io",
+                "squareUrl": "https://xgstudios.mypinata.cloud/ipfs/QmZP32SFcQ2rN2diEXsnwyFxZ5dmyFhuqAybDRANg2cEsk/XG_MOVE_THUMBNAIL.png", 
+                "bannerUrl": "https://xgstudios.mypinata.cloud/ipfs/QmZP32SFcQ2rN2diEXsnwyFxZ5dmyFhuqAybDRANg2cEsk/XG_MOVE_COLLECTION_BANNER.png",
+                "discord": "https://discord.com/invite/uaYhFARqXM", 
+                "instagram": "https://www.instagram.com/xGStudios_/", 
+                "twitter": "https://twitter.com/xGStudios_"
             }
         actorResource.createNewBrand(
             brandName: brandName,

--- a/transactions/createLegacyTemplateStaticData.cdc
+++ b/transactions/createLegacyTemplateStaticData.cdc
@@ -1,0 +1,33 @@
+import XGStudio from "../contracts/XGStudio.cdc"
+
+
+transaction(brandId:UInt64, schemaId:UInt64, maxSupply:UInt64) {
+    prepare(acct: AuthAccount) {
+
+        let actorResource = acct.getCapability
+            <&{XGStudio.NFTMethodsCapability}>
+            (XGStudio.NFTMethodsCapabilityPrivatePath)
+            .borrow() ?? 
+            panic("could not borrow a reference to the NFTMethodsCapability interface")
+        
+        let immutableData : {String: AnyStruct} = {
+            "contentType" : "Image",
+            "contectUrl"  : "https://xgstudios.io",
+            "title"       : "Second NFT",
+            "title"       : "Win: Alexandra Park v Hilltop Women",
+            "xGRewardType": "Win",
+            "competition":"Greater London Women''s Football League",
+            "fixtureType":"Division 2 North",
+            "activityType":"Football",
+            "season":"2022/23",
+            "playerTeam":"Hilltop Women",
+            "oppositionTeam":"Alexandra Park",
+            "date":"04/09/2022",
+            "venue":"A",
+            "result":"W",
+            "score":"0 - 16"
+        }
+        actorResource.createTemplate(brandId: brandId, schemaId: schemaId, maxSupply: maxSupply, immutableData: immutableData)
+        log("Template created")
+    }
+}

--- a/transactions/createSchema.cdc
+++ b/transactions/createSchema.cdc
@@ -21,7 +21,8 @@ transaction (schemaName:String){
             "raceDescription"   : XGStudio.SchemaType.String,
             "raceLocation" :XGStudio.SchemaType.String,
             "activityType"   : XGStudio.SchemaType.String,
-            "distance" :XGStudio.SchemaType.Fix64
+            "distance" :XGStudio.SchemaType.Fix64,
+            "thumbnail" : XGStudio.SchemaType.String
             }
 
         actorResource.createSchema(schemaName: schemaName, format: format)

--- a/transactions/createTemplateStaticData.cdc
+++ b/transactions/createTemplateStaticData.cdc
@@ -22,7 +22,8 @@ transaction(brandId:UInt64, schemaId:UInt64, maxSupply:UInt64) {
             "raceDescription": "Lion race",
             "raceLocation" : "Mian Essa",
             "activityType" : "Running",
-            "distance"     :  2000.0 as Fix64
+            "distance"     :  2000.0 as Fix64,
+            "thumbnail"    : "IPFSCID"
         }
         actorResource.createTemplate(brandId: brandId, schemaId: schemaId, maxSupply: maxSupply, immutableData: immutableData)
         log("Template created")


### PR DESCRIPTION
This adds metadata views as required by the NFT catalogue.

Based on #1 which should be merged first

---

Supported views:

```
MetadataViews.Display
MetadataViews.Editions
MetadataViews.NFTCollectionDisplay
MetadataViews.ExternalURL
MetadataViews.NFTCollectionData
MetadataViews.Royalties
MetadataViews.Serial
```

## Todo

* [x] Mapping and fallback for legacy template thumbnails
* [x] Implement dynamic editions functionality (Editions based nft type)
* [x] Set website URL fallback
* [ ] Add functionality to generate dynamic socials list
* [x] Implement royalties